### PR TITLE
few fixes regarding executing terminal commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,32 +6,25 @@
 ### Added
 
 ### Changed
-- Updating Readme to latest badges with new plugin id
+- Updating Readme to the latest badges with new plugin id
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+- Fixed to use `nx generate` vs `ng generate` in executing commands
+- Fixed flag values that have spaces to be wrapped in single quotes
 
 ### Security
 ## [0.1.1]
-### Added
-
-### Changed
-
-### Deprecated
-
-### Removed
-
 ### Fixed
 - Fixed terminal commands so that it won't add flags that have empty values
 
-### Security
-## [0.1.0] - 2020-09-09
+## [0.1.0]
 ### Fixed
 - Fixed terminal commands generated on non custom schematics (such as @nrwl/workspace).
 
 
-## [0.0.2] - 2020-09-07
+## [0.0.2]
 ### Added
 - `Generate` menu option to run schematics (including custom schematics) with `Dry Run` option.

--- a/README.md
+++ b/README.md
@@ -4,15 +4,6 @@
 [![Version](https://img.shields.io/jetbrains/plugin/v/com.github.etkachev.nxwebstorm.svg)](https://plugins.jetbrains.com/plugin/15000-nx-webstorm)
 [![Downloads](https://img.shields.io/jetbrains/plugin/d/com.github.etkachev.nxwebstorm.svg)](https://plugins.jetbrains.com/plugin/15000-nx-webstorm)
 
-## Template ToDo list
-- [x] Create a new [IntelliJ Platform Plugin Template][template] project.
-- [x] Verify the [pluginGroup](/gradle.properties), [plugin ID](/src/main/resources/META-INF/plugin.xml) and [sources package](/src/main/kotlin).
-- [x] Review the [Legal Agreements](https://plugins.jetbrains.com/docs/marketplace/legal-agreements.html).
-- [x] [Publish a plugin manually](https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/publishing_plugin.html) for the first time.
-- [x] Set the Plugin ID in the above README badges.
-- [x] Set the [Deployment Token](https://plugins.jetbrains.com/docs/marketplace/plugin-upload.html).
-- [x] Click the <kbd>Watch</kbd> button on the top of the [IntelliJ Platform Plugin Template][template] to be notified about releases containing new features and fixes.
-
 <!-- Plugin description -->
 
 This plugin is the Webstorm version of [Nx Console](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console) or at least in the process to be.
@@ -43,6 +34,14 @@ And for this alpha release, this plugin will support the `Generate` functionalit
   Download the [latest release](https://github.com/etkachev/nx-webstorm/releases/latest) and install it manually using
   <kbd>Preferences</kbd> > <kbd>Plugins</kbd> > <kbd>⚙️</kbd> > <kbd>Install plugin from disk...</kbd>
 
+## Template ToDo list
+- [x] Create a new [IntelliJ Platform Plugin Template][template] project.
+- [x] Verify the [pluginGroup](/gradle.properties), [plugin ID](/src/main/resources/META-INF/plugin.xml) and [sources package](/src/main/kotlin).
+- [x] Review the [Legal Agreements](https://plugins.jetbrains.com/docs/marketplace/legal-agreements.html).
+- [x] [Publish a plugin manually](https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/publishing_plugin.html) for the first time.
+- [x] Set the Plugin ID in the above README badges.
+- [x] Set the [Deployment Token](https://plugins.jetbrains.com/docs/marketplace/plugin-upload.html).
+- [x] Click the <kbd>Watch</kbd> button on the top of the [IntelliJ Platform Plugin Template][template] to be notified about releases containing new features and fixes.
 
 ---
 Plugin based on the [IntelliJ Platform Plugin Template][template].

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/utils/GenerateTerminalCommand.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/utils/GenerateTerminalCommand.kt
@@ -13,13 +13,14 @@ fun getSchematicCommandFromValues(
     val finalText = if (value == "true" || value == "false") {
       if (value == "true") "--$key" else null
     } else if (value != null && value.isNotBlank()) {
-      "--$key=$value"
+      val cleanedValue = if (value.contains(" ")) "'$value'" else value
+      "--$key=$cleanedValue"
     } else {
       null
     }
     finalText
   }
-  val prefix = if (type == "workspace-schematic") "nx workspace-schematic $id" else "ng generate $type:$id"
+  val prefix = if (type == "workspace-schematic") "nx workspace-schematic $id" else "nx generate $type:$id"
   val flags = flagCommands.joinToString(" ")
   return "$prefix $flags --no-interactive$dryRunString"
 }


### PR DESCRIPTION
## Fixes
- Using `nx` command instead of `ng` for executing terminal commands
- Wrapping flag values that contain spaces inside single quotes when executing commands

## Docs
- Cleanup the readme and changelog

CLOSES #1 
CLOSES #3 