### PR TITLE
fix: tab switching on DryRun/Run and required fields flow fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 # nx-webstorm Changelog
 
 ## [Unreleased]
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.1.2]
 ### Changed
 - Updating Readme to the latest badges with new plugin id
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 ### Removed
 
 ### Fixed
+- When going between doing `Dry Run` and `Run`, UI now switches tabs to the currently running shell.
+- When there are required fields that aren't filled out, it won't run the terminal commands anymore
 
 ### Security
 

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/actionlisteners/SchematicSelectionTabListener.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/actionlisteners/SchematicSelectionTabListener.kt
@@ -46,7 +46,10 @@ class SchematicSelectionTabListener(
 
   private fun run(type: String, id: String, formMap: FormValueMap, required: JsonArray?, dryRun: Boolean = true) {
     val values = formMap.formVal
-    checkRequiredFields(required, values)
+    val missingRequired = checkRequiredFields(required, values)
+    if (missingRequired) {
+      return
+    }
     val command = getSchematicCommandFromValues(type, id, values, dryRun)
     if (dryRun) {
       dryRunTerminal.runAndShow(command)
@@ -55,21 +58,22 @@ class SchematicSelectionTabListener(
     }
   }
 
-  private fun checkRequiredFields(required: JsonArray?, values: MutableMap<String, String>) {
+  private fun checkRequiredFields(required: JsonArray?, values: MutableMap<String, String>): Boolean {
     if (required == null) {
-      return
+      return false
     }
 
     val mappedRequired = required.mapNotNull { r -> r.asString }.toTypedArray()
     val missing =
       values.keys.filter { k -> mappedRequired.contains(k) && (values[k] == null || values[k]!!.trim() == "") }
     if (missing.count() == 0) {
-      return
+      return false
     }
 
     val joinedKeys = missing.joinToString()
     val message = "Missing the following required fields: $joinedKeys"
     Messages.showMessageDialog(message, "Oops", Messages.getWarningIcon())
+    return true
   }
 
   override fun valueChanged(e: ListSelectionEvent?) {

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/actionlisteners/SchematicSelectionTabListener.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/actionlisteners/SchematicSelectionTabListener.kt
@@ -46,8 +46,7 @@ class SchematicSelectionTabListener(
 
   private fun run(type: String, id: String, formMap: FormValueMap, required: JsonArray?, dryRun: Boolean = true) {
     val values = formMap.formVal
-    val missingRequired = checkRequiredFields(required, values)
-    if (missingRequired) {
+    if (isMissingRequiredFields(required, values)) {
       return
     }
     val command = getSchematicCommandFromValues(type, id, values, dryRun)
@@ -58,7 +57,7 @@ class SchematicSelectionTabListener(
     }
   }
 
-  private fun checkRequiredFields(required: JsonArray?, values: MutableMap<String, String>): Boolean {
+  private fun isMissingRequiredFields(required: JsonArray?, values: MutableMap<String, String>): Boolean {
     if (required == null) {
       return false
     }


### PR DESCRIPTION
## Current Behavior
- When trying to run (or dry run) a schematic, but you didn't fill out all required fields, the warning comes up, but it still runs the commands when closing warning message.
- Going between `Dry Run` and `Run` commands does not switch tabs even though commands are run in the background.

## Expected Behavior
- If warning comes up about required fields not filled out, it should not run the commands.
- Switching between `Dry Run` and `Run` commands should also switch to the corresponding tabs.

## Related Issues
CLOSES #7 