### PR TITLE
feat: use Nx CLI from node_modules

### DIFF
--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/utils/GenerateTerminalCommand.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/utils/GenerateTerminalCommand.kt
@@ -20,7 +20,7 @@ fun getSchematicCommandFromValues(
     }
     finalText
   }
-  val nx = "node node_modules/@nrwl/cli/bin/nx.js";
+  val nx = "node node_modules/@nrwl/cli/bin/nx.js"
   val prefix = if (type == "workspace-schematic") "$nx workspace-schematic $id" else "$nx generate $type:$id"
   val flags = flagCommands.joinToString(" ")
   return "$prefix $flags --no-interactive$dryRunString"

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/utils/GenerateTerminalCommand.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/utils/GenerateTerminalCommand.kt
@@ -20,7 +20,8 @@ fun getSchematicCommandFromValues(
     }
     finalText
   }
-  val prefix = if (type == "workspace-schematic") "nx workspace-schematic $id" else "nx generate $type:$id"
+  val nx = "node node_modules/@nrwl/cli/bin/nx.js";
+  val prefix = if (type == "workspace-schematic") "$nx workspace-schematic $id" else "$nx generate $type:$id"
   val flags = flagCommands.joinToString(" ")
   return "$prefix $flags --no-interactive$dryRunString"
 }


### PR DESCRIPTION
## Current Behavior

<!-- The behavior we have today before this PR is merged -->

User needs to have Nx installed globally.

## Expected Behavior

<!-- The behavior we will have after the PR is merged -->

The locally installed version of Nx should be used.

## Motivation

<!-- Why is this behavior expected? -->

- user might not have Nx installed globally
- global version might be different to project required version

## Related Issue

<!-- Please link an issue from github -->
<!-- that may provide more information regarding this PR -->

#2 

## Additional Notes

<!-- ... -->
