### PR TITLE
fix: double clicking on buttons to run commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,23 +12,16 @@
 ### Removed
 
 ### Fixed
+- If shell tab is still executing commands, do not try to run commands again. 
 
 ### Security
 ## [0.2.0]
-### Added
-
 ### Changed
 - When running nx commands, use local installed nx cli instead of global
-
-### Deprecated
-
-### Removed
 
 ### Fixed
 - When going between doing `Dry Run` and `Run`, UI now switches tabs to the currently running shell.
 - When there are required fields that aren't filled out, it won't run the terminal commands anymore
-
-### Security
 
 ## [0.1.2]
 ### Changed

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/RunTerminalWindow.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/RunTerminalWindow.kt
@@ -35,6 +35,10 @@ class RunTerminalWindow(private val proj: Project, private val tabName: String? 
 
     // If tab with matching name doesn't exist, create new shell instance with matching tab name
     val existingTab = window.contentManager.findContent(tabName) ?: createShell(window)
+    // If shell is still running commands, don't continue
+    if (shell!!.hasRunningCommands()) {
+      return
+    }
     window.show()
     window.contentManager.setSelectedContent(existingTab)
     shell!!.executeCommand(command)


### PR DESCRIPTION
## Current Behavior

<!-- The behavior we have today before this PR is merged -->
- When trying to run (or dry run) schematic, if user clicks on same button twice while terminal is still executing first command, then next action queues.

## Expected Behavior

<!-- The behavior we will have after the PR is merged -->
- If shell instance is still running a command, then if user clicks on the same button again, nothing happens.
- User would have to click the button (Dry Run or Run) again after the original command has finished executing.

## Motivation

<!-- Why is this behavior expected? -->
No more double clicking funny business.

## Related Issue

<!-- Please link an issue from github -->
<!-- that may provide more information regarding this PR -->
CLOSES #6 

## Additional Notes

<!-- ... -->
