### PR TITLE
feat: adding refresh listener for list of schematics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## [Unreleased]
 ### Added
+- Added mechanism to refresh list of schematics. Should be a button next to the search bar on panel showing list of schematics.
 
 ### Changed
 

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/actionlisteners/ReFetchSchematicsListener.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/actionlisteners/ReFetchSchematicsListener.kt
@@ -1,0 +1,36 @@
+package com.github.etkachev.nxwebstorm.actionlisteners
+
+import com.github.etkachev.nxwebstorm.ui.SchematicsListToolTab
+import com.github.etkachev.nxwebstorm.utils.FindAllSchematics
+import com.intellij.openapi.wm.ToolWindow
+import com.intellij.ui.content.ContentFactory
+import java.awt.event.ActionEvent
+
+class ReFetchSchematicsListener(
+  private val toolWindow: ToolWindow,
+  private val contentFactory: ContentFactory,
+  private val tabName: String,
+  private val schematicToolTab: SchematicsListToolTab,
+  private val schematicFetcher: FindAllSchematics
+) {
+
+  /**
+   * gets the action listener re-fetching schematics.
+   */
+  fun getActionListener(removeOldListener: () -> Unit): (ActionEvent) -> Unit {
+    return { fetchSchematics(removeOldListener) }
+  }
+
+  /**
+   * will remove the old listener and grab all the schematics again,
+   * and re-adding it to the tool-window content
+   */
+  private fun fetchSchematics(removeOldListener: () -> Unit) {
+    removeOldListener()
+    val allSchematics = schematicFetcher.findAll()
+    val listPanel = schematicToolTab.createCenterPanel(allSchematics)
+    val content = contentFactory.createContent(listPanel, tabName, false)
+    toolWindow.contentManager.removeAllContents(true)
+    toolWindow.contentManager.addContent(content)
+  }
+}

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/GenerateToolWindow.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/GenerateToolWindow.kt
@@ -11,8 +11,12 @@ class GenerateToolWindow : ToolWindowFactory {
   private var tabName = "Generate"
   override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
     val contentFactory = ContentFactory.SERVICE.getInstance()
-    val allSchematics = FindAllSchematics(project).findAll()
-    val listPanel = SchematicsListToolTab(project, allSchematics).createCenterPanel(toolWindow)
+    val schematicFetcher = FindAllSchematics(project)
+    val allSchematics = schematicFetcher.findAll()
+    val listPanel =
+      SchematicsListToolTab(project, toolWindow, contentFactory, tabName, schematicFetcher).createCenterPanel(
+        allSchematics
+      )
     val content = contentFactory.createContent(listPanel, tabName, false)
     toolWindow.contentManager.addContent(content)
   }

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/SchematicsListToolTab.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/SchematicsListToolTab.kt
@@ -27,10 +27,17 @@ class SchematicsListToolTab(
     tabName, this, schematicFetcher
   )
 
+  /**
+   * Return function that will be used within `ReFetchSchematicListener` to cleanup un-needed listener.
+   * Honestly I don't know if this is automatically cleaned up with the garbage collector, but just in case...
+   */
   private fun getRemoveSelectionListener(table: JBTable, listener: SchematicSelectionTabListener): () -> Unit {
     return { removeRowSelectionListener(table, listener) }
   }
 
+  /**
+   * function that is used to remove list selection listener for the given table passed in.
+   */
   private fun removeRowSelectionListener(table: JBTable, listener: SchematicSelectionTabListener) {
     table.selectionModel.removeListSelectionListener(listener)
   }

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/SchematicsListToolTab.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/SchematicsListToolTab.kt
@@ -1,39 +1,68 @@
 package com.github.etkachev.nxwebstorm.ui
 
+import com.github.etkachev.nxwebstorm.actionlisteners.ReFetchSchematicsListener
 import com.github.etkachev.nxwebstorm.actionlisteners.SchematicSelectionTabListener
 import com.github.etkachev.nxwebstorm.models.SchematicInfo
+import com.github.etkachev.nxwebstorm.utils.FindAllSchematics
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.content.ContentFactory
 import com.intellij.ui.layout.panel
+import com.intellij.ui.table.JBTable
 import javax.swing.BorderFactory
 import javax.swing.JComponent
 
 class SchematicsListToolTab(
   val project: Project,
-  private val schematics: Map<String, SchematicInfo>
+  private val toolWindow: ToolWindow,
+  contentFactory: ContentFactory,
+  tabName: String,
+  schematicFetcher: FindAllSchematics
 ) {
 
-  fun createCenterPanel(toolWindow: ToolWindow): JComponent? {
+  private var reFetchListener: ReFetchSchematicsListener = ReFetchSchematicsListener(
+    toolWindow,
+    contentFactory,
+    tabName, this, schematicFetcher
+  )
+
+  private fun getRemoveSelectionListener(table: JBTable, listener: SchematicSelectionTabListener): () -> Unit {
+    return { removeRowSelectionListener(table, listener) }
+  }
+
+  private fun removeRowSelectionListener(table: JBTable, listener: SchematicSelectionTabListener) {
+    table.selectionModel.removeListSelectionListener(listener)
+  }
+
+  fun createCenterPanel(schematics: Map<String, SchematicInfo>): JComponent? {
     val generateTable = GenerateTable(schematics)
     val tableData = generateTable.getTable()
     val searchField = tableData.field
     val table = tableData.table
-    table.selectionModel.addListSelectionListener(
-      SchematicSelectionTabListener(
-        project,
-        table,
-        schematics,
-        toolWindow,
-        searchField
-      )
+    val listener = SchematicSelectionTabListener(
+      project,
+      table,
+      schematics,
+      toolWindow,
+      searchField
     )
+    table.selectionModel.addListSelectionListener(
+      listener
+    )
+    val removeListener = getRemoveSelectionListener(table, listener)
     val scrollPane = JBScrollPane(table)
 
     val border = BorderFactory.createEmptyBorder(10, 10, 10, 10)
     return panel {
       row {
         searchField()
+        right {
+          button(
+            "Refresh",
+            reFetchListener.getActionListener(removeListener)
+          )
+        }
       }
       row {
         scrollPane()


### PR DESCRIPTION
## Current Behavior

<!-- The behavior we have today before this PR is merged -->
- There is no way to refresh list of available schematics (in scenario where you generate new schematic)

## Expected Behavior

<!-- The behavior we will have after the PR is merged -->
- There should be a `Refresh` button next to the search bar on list of schematics.
- Upon clicking on the button, it should refresh the panel that shows the list of available schematics.

## Motivation

<!-- Why is this behavior expected? -->
- So we don't need to reopen webstorm everytime we create a new schematic 😆 

## Related Issue

<!-- Please link an issue from github -->
<!-- that may provide more information regarding this PR -->
CLOSES #13 

## Additional Notes

<!-- ... -->
