### PR TITLE
chore: prepare-release of 0.2.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # -> https://www.jetbrains.org/intellij/sdk/docs/reference_guide/intellij_artifacts.html
 pluginGroup=com.github.etkachev.nxwebstorm
 pluginName=nx-webstorm
-pluginVersion=0.2.0
+pluginVersion=0.2.1
 pluginSinceBuild=202
 pluginUntilBuild=202.*
 platformType=IU


### PR DESCRIPTION
## Current Behavior

<!-- The behavior we have today before this PR is merged -->
Plugin version is at `0.2.0`

## Expected Behavior

<!-- The behavior we will have after the PR is merged -->
Update version of plugin to `0.2.1`

## Motivation

<!-- Why is this behavior expected? -->
Prepare for release

## Related Issue

<!-- Please link an issue from github -->
<!-- that may provide more information regarding this PR -->

## Additional Notes

<!-- ... -->
