### PR TITLE
feat: plugin settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## [Unreleased]
 ### Added
+- Added settings to configure plugin. Be able to configure things such as external packages to scan for schematics, and configuring location of custom schematics.
 
 ### Changed
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,18 +4,18 @@ import org.jetbrains.changelog.markdownToHTML
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    // Java support
-    id("java")
-    // Kotlin support
-    id("org.jetbrains.kotlin.jvm") version "1.3.72"
-    // gradle-intellij-plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
-    id("org.jetbrains.intellij") version "0.4.21"
-    // gradle-changelog-plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
-    id("org.jetbrains.changelog") version "0.4.0"
-    // detekt linter - read more: https://detekt.github.io/detekt/kotlindsl.html
-    id("io.gitlab.arturbosch.detekt") version "1.10.0"
-    // ktlint linter - read more: https://github.com/JLLeitschuh/ktlint-gradle
-    id("org.jlleitschuh.gradle.ktlint") version "9.2.1"
+  // Java support
+  id("java")
+  // Kotlin support
+  id("org.jetbrains.kotlin.jvm") version "1.3.72"
+  // gradle-intellij-plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
+  id("org.jetbrains.intellij") version "0.4.21"
+  // gradle-changelog-plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
+  id("org.jetbrains.changelog") version "0.4.0"
+  // detekt linter - read more: https://detekt.github.io/detekt/kotlindsl.html
+  id("io.gitlab.arturbosch.detekt") version "1.10.0"
+  // ktlint linter - read more: https://github.com/JLLeitschuh/ktlint-gradle
+  id("org.jlleitschuh.gradle.ktlint") version "9.2.1"
 }
 
 // Import variables from gradle.properties file
@@ -34,84 +34,84 @@ version = pluginVersion
 
 // Configure project's dependencies
 repositories {
-    mavenCentral()
-    jcenter()
+  mavenCentral()
+  jcenter()
 }
 dependencies {
-    implementation(kotlin("stdlib-jdk8"))
-    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.10.0")
+  implementation(kotlin("stdlib-jdk8"))
+  detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.10.0")
 }
 
 // Configure gradle-intellij-plugin plugin.
 // Read more: https://github.com/JetBrains/gradle-intellij-plugin
 intellij {
-    pluginName = pluginName
-    version = platformVersion
-    type = platformType
-    downloadSources = platformDownloadSources.toBoolean()
-    updateSinceUntilBuild = true
+  pluginName = pluginName
+  version = platformVersion
+  type = platformType
+  downloadSources = platformDownloadSources.toBoolean()
+  updateSinceUntilBuild = true
 
 //  Plugin Dependencies:
 //  https://www.jetbrains.org/intellij/sdk/docs/basics/plugin_structure/plugin_dependencies.html
-    setPlugins("JavaScriptLanguage", "terminal")
+  setPlugins("JavaScriptLanguage", "terminal")
 }
 
 // Configure detekt plugin.
 // Read more: https://detekt.github.io/detekt/kotlindsl.html
 detekt {
-    config = files("./detekt-config.yml")
-    buildUponDefaultConfig = true
+  config = files("./detekt-config.yml")
+  buildUponDefaultConfig = true
 
-    reports {
-        html.enabled = false
-        xml.enabled = false
-        txt.enabled = false
-    }
+  reports {
+    html.enabled = false
+    xml.enabled = false
+    txt.enabled = false
+  }
 }
 
 tasks {
-    // Set the compatibility versions to 1.8
-    withType<JavaCompile> {
-        sourceCompatibility = "1.8"
-        targetCompatibility = "1.8"
+  // Set the compatibility versions to 1.8
+  withType<JavaCompile> {
+    sourceCompatibility = "1.8"
+    targetCompatibility = "1.8"
+  }
+  listOf("compileKotlin", "compileTestKotlin").forEach {
+    getByName<KotlinCompile>(it) {
+      kotlinOptions.jvmTarget = "1.8"
     }
-    listOf("compileKotlin", "compileTestKotlin").forEach {
-        getByName<KotlinCompile>(it) {
-            kotlinOptions.jvmTarget = "1.8"
-        }
-    }
+  }
 
-    runIde {
-        setIdeDirectory(
-            "/Users/edwardtkachev/Library/Application Support/JetBrains/Toolbox/apps/WebStorm/ch-0/202.6397.88/WebStorm.app/Contents"
-        )
-    }
+  runIde {
+    setIdeDirectory(
+      "/Users/edwardtkachev/Library/Application Support/JetBrains/Toolbox/apps/WebStorm/ch-0/202.7660.23/WebStorm.app/Contents"
+    )
+  }
 
-    withType<Detekt> {
-        jvmTarget = "1.8"
-    }
+  withType<Detekt> {
+    jvmTarget = "1.8"
+  }
 
-    patchPluginXml {
-        version(pluginVersion)
-        sinceBuild(pluginSinceBuild)
-        untilBuild(pluginUntilBuild)
+  patchPluginXml {
+    version(pluginVersion)
+    sinceBuild(pluginSinceBuild)
+    untilBuild(pluginUntilBuild)
 
-        // Extract the <!-- Plugin description --> section from README.md and provide for the plugin's manifest
-        pluginDescription(closure {
-            File("./README.md").readText().lines().run {
-                subList(indexOf("<!-- Plugin description -->") + 1, indexOf("<!-- Plugin description end -->"))
-            }.joinToString("\n").run { markdownToHTML(this) }
-        })
+    // Extract the <!-- Plugin description --> section from README.md and provide for the plugin's manifest
+    pluginDescription(closure {
+      File("./README.md").readText().lines().run {
+        subList(indexOf("<!-- Plugin description -->") + 1, indexOf("<!-- Plugin description end -->"))
+      }.joinToString("\n").run { markdownToHTML(this) }
+    })
 
-        // Get the latest available change notes from the changelog file
-        changeNotes(closure {
-            changelog.getLatest().toHTML()
-        })
-    }
+    // Get the latest available change notes from the changelog file
+    changeNotes(closure {
+      changelog.getLatest().toHTML()
+    })
+  }
 
-    publishPlugin {
-        dependsOn("patchChangelog")
-        token(System.getenv("PUBLISH_TOKEN"))
-        channels(pluginVersion.split('-').getOrElse(1) { "default" }.split('.').first())
-    }
+  publishPlugin {
+    dependsOn("patchChangelog")
+    token(System.getenv("PUBLISH_TOKEN"))
+    channels(pluginVersion.split('-').getOrElse(1) { "default" }.split('.').first())
+  }
 }

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/actions/NxActionGroup.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/actions/NxActionGroup.kt
@@ -12,7 +12,7 @@ class NxActionGroup : DefaultActionGroup() {
       event.presentation.isEnabled = false
       return
     }
-    val isValidNx = GetNxData().isValidNxProject(project)
+    val isValidNx = GetNxData(project).isValidNxProject()
     event.presentation.isEnabled = isValidNx
   }
 }

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/GenerateToolWindow.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/GenerateToolWindow.kt
@@ -22,6 +22,6 @@ class GenerateToolWindow : ToolWindowFactory {
   }
 
   override fun isApplicable(project: Project): Boolean {
-    return GetNxData().isValidNxProject(project)
+    return GetNxData(project).isValidNxProject()
   }
 }

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/ExternalSchematicsSettingsComponent.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/ExternalSchematicsSettingsComponent.kt
@@ -1,0 +1,51 @@
+package com.github.etkachev.nxwebstorm.ui.settings
+
+import com.intellij.ui.ToolbarDecorator
+import com.intellij.ui.components.JBList
+import javax.swing.DefaultListModel
+import javax.swing.JComponent
+import javax.swing.JPanel
+
+class ExternalSchematicsSettingsComponent {
+  val panel: JPanel
+  private var externalSchematicsList: JBList<String>
+
+  val preferredFocusedComponent: JComponent
+    get() = externalSchematicsList
+
+  var externalSchematics: Array<String>
+    get() = Array(externalSchematicsList.model.size) { i -> externalSchematicsList.model.getElementAt(i) }
+    set(list) {
+      val newList = DefaultListModel<String>()
+      for (item in list) {
+        newList.addElement(item.trim())
+      }
+      externalSchematicsList.model = newList
+    }
+
+  init {
+    val list = JBList<String>()
+    externalSchematicsList = list
+    panel = ToolbarDecorator.createDecorator(list).setAddAction { addLine() }.setRemoveAction { removeLine() }
+      .disableUpDownActions().createPanel()
+  }
+
+  private fun addLine() {
+    val externalSchemDialog = NewExternalSchematicDialog(externalSchematics)
+    if (externalSchemDialog.showAndGet()) {
+      val newExternalSchem = externalSchemDialog.packageNameText
+      val currentList = externalSchematicsList.model as DefaultListModel<String>
+      currentList.addElement(newExternalSchem)
+      externalSchematicsList.model = currentList
+    }
+  }
+
+  private fun removeLine() {
+    val selectedItemIndex = externalSchematicsList.selectedIndex
+    if (selectedItemIndex > -1) {
+      val currentList = externalSchematics.toMutableList()
+      currentList.removeAt(selectedItemIndex)
+      externalSchematics = currentList.toTypedArray()
+    }
+  }
+}

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/ExternalSchematicsSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/ExternalSchematicsSettingsConfigurable.kt
@@ -1,0 +1,43 @@
+package com.github.etkachev.nxwebstorm.ui.settings
+
+import com.intellij.openapi.options.Configurable
+import javax.swing.JComponent
+
+class ExternalSchematicsSettingsConfigurable : Configurable {
+  private var externalSchematicsComponent: ExternalSchematicsSettingsComponent? = null
+
+  override fun createComponent(): JComponent? {
+    externalSchematicsComponent = ExternalSchematicsSettingsComponent()
+    return externalSchematicsComponent!!.panel
+  }
+
+  override fun isModified(): Boolean {
+    val settings: PluginSettingsState = PluginSettingsState.instance
+    val current = settings.externalLibs
+    val newList = externalSchematicsComponent!!.externalSchematics.joinToString(",")
+    return newList != current
+  }
+
+  override fun apply() {
+    val settings: PluginSettingsState = PluginSettingsState.instance
+    settings.externalLibs = externalSchematicsComponent!!.externalSchematics.joinToString(",")
+  }
+
+  override fun getPreferredFocusedComponent(): JComponent {
+    return externalSchematicsComponent!!.preferredFocusedComponent
+  }
+
+  override fun getDisplayName(): String {
+    val hi = "jetbrains://WebStorm/settings?name=Tools--Nx+Plugin+Settings--External+Schematics"
+    return "External Schematics"
+  }
+
+  override fun reset() {
+    val settings: PluginSettingsState = PluginSettingsState.instance
+    externalSchematicsComponent!!.externalSchematics = settings.externalLibs.split(",").toTypedArray()
+  }
+
+  override fun disposeUIResources() {
+    externalSchematicsComponent = null
+  }
+}

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/ExternalSchematicsSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/ExternalSchematicsSettingsConfigurable.kt
@@ -28,7 +28,6 @@ class ExternalSchematicsSettingsConfigurable : Configurable {
   }
 
   override fun getDisplayName(): String {
-    val hi = "jetbrains://WebStorm/settings?name=Tools--Nx+Plugin+Settings--External+Schematics"
     return "External Schematics"
   }
 

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/NewExternalSchematicDialog.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/NewExternalSchematicDialog.kt
@@ -11,7 +11,6 @@ class NewExternalSchematicDialog(private val existingList: Array<String>) : Dial
 
   init {
     super.init()
-    super.initValidation()
     super.setTitle("New Item")
   }
 
@@ -28,6 +27,10 @@ class NewExternalSchematicDialog(private val existingList: Array<String>) : Dial
   }
 
   private fun validateText(field: JBTextField): ValidationInfo? {
+    val emptyText = field.text.isNullOrEmpty()
+    if (emptyText) {
+      return ValidationInfo("Cannot be empty", field)
+    }
     val alreadyExists = existingList.find { s -> s == field.text } ?: return null
     return ValidationInfo("$alreadyExists is already in use. Try something else.", field)
   }

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/NewExternalSchematicDialog.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/NewExternalSchematicDialog.kt
@@ -1,0 +1,42 @@
+package com.github.etkachev.nxwebstorm.ui.settings
+
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.openapi.ui.ValidationInfo
+import com.intellij.ui.components.JBTextField
+import com.intellij.ui.layout.panel
+import javax.swing.JComponent
+
+class NewExternalSchematicDialog(private val existingList: Array<String>) : DialogWrapper(null) {
+  var packageNameText: String = ""
+
+  init {
+    super.init()
+    super.initValidation()
+    super.setTitle("New Item")
+  }
+
+  override fun createCenterPanel(): JComponent? {
+    return panel {
+      row {
+        label("Enter package name to scan")
+      }
+      row {
+        textField({ getText() }, { value -> setText(value) }).withValidationOnInput { field -> validateText(field) }
+          .focused()
+      }
+    }
+  }
+
+  private fun validateText(field: JBTextField): ValidationInfo? {
+    val alreadyExists = existingList.find { s -> s == field.text } ?: return null
+    return ValidationInfo("$alreadyExists is already in use. Try something else.", field)
+  }
+
+  private fun getText(): String {
+    return packageNameText
+  }
+
+  private fun setText(value: String) {
+    packageNameText = value
+  }
+}

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginSettingsComponent.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginSettingsComponent.kt
@@ -25,8 +25,8 @@ class PluginSettingsComponent {
 
     val checkBox =
       JBCheckBox(
-        "Scan only explicit external libs (recommended). " +
-          "If off, it will scan all of node_modules (not recommended)."
+        "Scan only explicit external libs (faster). " +
+          "If off, it will scan all of node_modules (slower)."
       )
     myScanExplicitLibsStatus = checkBox
   }

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginSettingsComponent.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginSettingsComponent.kt
@@ -1,0 +1,56 @@
+package com.github.etkachev.nxwebstorm.ui.settings
+
+import com.intellij.ui.components.JBCheckBox
+import com.intellij.ui.components.JBTextArea
+import javax.swing.JComponent
+import javax.swing.JPanel
+import com.intellij.ui.layout.panel
+import javax.swing.BorderFactory
+
+/**
+ * Supports creating and managing a JPanel for the Settings Dialog.
+ */
+class PluginSettingsComponent {
+  val panel: JPanel
+  private val myExternalLibsField: JBTextArea
+  private val myScanEverythingStatus = JBCheckBox("Scan all node_modules? This may take longer to find all schematics")
+
+  init {
+    val textArea = JBTextArea(5, 20)
+    textArea.lineWrap = true
+    textArea.wrapStyleWord = true
+    textArea.border = BorderFactory.createEmptyBorder(10, 10, 10, 10)
+    myExternalLibsField = textArea
+  }
+
+  val preferredFocusedComponent: JComponent
+    get() = myExternalLibsField
+  var externalLibsText: String
+    get() = myExternalLibsField.text
+    set(libs) {
+      myExternalLibsField.text = libs
+    }
+  var scanEverythingStatus: Boolean
+    get() = myScanEverythingStatus.isSelected
+    set(newStatus) {
+      myScanEverythingStatus.isSelected = newStatus
+    }
+
+  init {
+    panel = panel {
+      titledRow("External Libs") {
+        row {
+          label("Enter external libs to scan:")
+        }
+        row {
+          myExternalLibsField()
+        }
+      }
+      titledRow("Scan Everything? (WIP)") {
+        row {
+          myScanEverythingStatus()
+        }
+      }
+    }.withBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10))
+  }
+}

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginSettingsComponent.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginSettingsComponent.kt
@@ -2,6 +2,7 @@ package com.github.etkachev.nxwebstorm.ui.settings
 
 import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.components.JBTextArea
+import com.intellij.ui.components.JBTextField
 import javax.swing.JComponent
 import javax.swing.JPanel
 import com.intellij.ui.layout.panel
@@ -15,6 +16,7 @@ class PluginSettingsComponent {
   val panel: JPanel
   private val myExternalLibsField: JBTextArea
   private val myScanExplicitLibsStatus: JBCheckBox
+  private val myCustomSchematicsDirectory: JBTextField = JBTextField()
 
   init {
     val textArea = JBTextArea(5, 20)
@@ -43,6 +45,11 @@ class PluginSettingsComponent {
     set(newStatus) {
       myScanExplicitLibsStatus.isSelected = newStatus
     }
+  var customSchematicsDirText: String
+    get() = myCustomSchematicsDirectory.text
+    set(dir) {
+      myCustomSchematicsDirectory.text = dir
+    }
 
   init {
     panel = panel {
@@ -57,6 +64,14 @@ class PluginSettingsComponent {
         }
         row {
           myExternalLibsField().enableIf(myScanExplicitLibsStatus.selected)
+        }
+      }
+      titledRow("Custom Schematics Directory") {
+        row {
+          label("Enter directory where custom schematics are located")
+        }
+        row {
+          myCustomSchematicsDirectory()
         }
       }
     }.withBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10))

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginSettingsComponent.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginSettingsComponent.kt
@@ -1,12 +1,11 @@
 package com.github.etkachev.nxwebstorm.ui.settings
 
+import com.intellij.ui.CollectionListModel
 import com.intellij.ui.components.JBCheckBox
-import com.intellij.ui.components.JBTextArea
 import com.intellij.ui.components.JBTextField
 import javax.swing.JComponent
 import javax.swing.JPanel
 import com.intellij.ui.layout.panel
-import com.intellij.ui.layout.selected
 import javax.swing.BorderFactory
 
 /**
@@ -14,32 +13,12 @@ import javax.swing.BorderFactory
  */
 class PluginSettingsComponent {
   val panel: JPanel
-  private val myExternalLibsField: JBTextArea
   private val myScanExplicitLibsStatus: JBCheckBox
   private val myCustomSchematicsDirectory: JBTextField = JBTextField()
-
-  init {
-    val textArea = JBTextArea(5, 20)
-    textArea.lineWrap = true
-    textArea.wrapStyleWord = true
-    textArea.border = BorderFactory.createEmptyBorder(10, 10, 10, 10)
-    myExternalLibsField = textArea
-
-    val checkBox =
-      JBCheckBox(
-        "Scan only explicit external libs (faster). " +
-          "If off, it will scan all of node_modules (slower)."
-      )
-    myScanExplicitLibsStatus = checkBox
-  }
+  private val myExternalLibsList: CollectionListModel<String>
 
   val preferredFocusedComponent: JComponent
-    get() = myExternalLibsField
-  var externalLibsText: String
-    get() = myExternalLibsField.text
-    set(libs) {
-      myExternalLibsField.text = libs
-    }
+    get() = myScanExplicitLibsStatus
   var scanExplicitLibsStatus: Boolean
     get() = myScanExplicitLibsStatus.isSelected
     set(newStatus) {
@@ -52,18 +31,21 @@ class PluginSettingsComponent {
     }
 
   init {
+    val checkBox =
+      JBCheckBox(
+        "Scan only explicit external libs (faster). " +
+          "If off, it will scan all of node_modules (slower)."
+      )
+    myScanExplicitLibsStatus = checkBox
+    myExternalLibsList = CollectionListModel()
+
     panel = panel {
-      titledRow("Scan Explicit External Libs? (WIP)") {
+      titledRow("Scan Explicit External Libs?") {
         row {
           myScanExplicitLibsStatus()
         }
-      }
-      titledRow("External Libs") {
         row {
-          label("Enter external libs to scan:")
-        }
-        row {
-          myExternalLibsField().enableIf(myScanExplicitLibsStatus.selected)
+          label("If turned on, head over to 'External Schematics' setting page to configure")
         }
       }
       titledRow("Custom Schematics Directory") {

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginSettingsComponent.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginSettingsComponent.kt
@@ -24,7 +24,10 @@ class PluginSettingsComponent {
     myExternalLibsField = textArea
 
     val checkBox =
-      JBCheckBox("Scan only explicit external libs (recommended). If off, it will scan all of node_modules (not recommended).")
+      JBCheckBox(
+        "Scan only explicit external libs (recommended). " +
+          "If off, it will scan all of node_modules (not recommended)."
+      )
     myScanExplicitLibsStatus = checkBox
   }
 

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginSettingsComponent.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginSettingsComponent.kt
@@ -5,6 +5,7 @@ import com.intellij.ui.components.JBTextArea
 import javax.swing.JComponent
 import javax.swing.JPanel
 import com.intellij.ui.layout.panel
+import com.intellij.ui.layout.selected
 import javax.swing.BorderFactory
 
 /**
@@ -13,7 +14,7 @@ import javax.swing.BorderFactory
 class PluginSettingsComponent {
   val panel: JPanel
   private val myExternalLibsField: JBTextArea
-  private val myScanEverythingStatus = JBCheckBox("Scan all node_modules? This may take longer to find all schematics")
+  private val myScanExplicitLibsStatus: JBCheckBox
 
   init {
     val textArea = JBTextArea(5, 20)
@@ -21,6 +22,10 @@ class PluginSettingsComponent {
     textArea.wrapStyleWord = true
     textArea.border = BorderFactory.createEmptyBorder(10, 10, 10, 10)
     myExternalLibsField = textArea
+
+    val checkBox =
+      JBCheckBox("Scan only explicit external libs (recommended). If off, it will scan all of node_modules (not recommended).")
+    myScanExplicitLibsStatus = checkBox
   }
 
   val preferredFocusedComponent: JComponent
@@ -30,25 +35,25 @@ class PluginSettingsComponent {
     set(libs) {
       myExternalLibsField.text = libs
     }
-  var scanEverythingStatus: Boolean
-    get() = myScanEverythingStatus.isSelected
+  var scanExplicitLibsStatus: Boolean
+    get() = myScanExplicitLibsStatus.isSelected
     set(newStatus) {
-      myScanEverythingStatus.isSelected = newStatus
+      myScanExplicitLibsStatus.isSelected = newStatus
     }
 
   init {
     panel = panel {
+      titledRow("Scan Explicit External Libs? (WIP)") {
+        row {
+          myScanExplicitLibsStatus()
+        }
+      }
       titledRow("External Libs") {
         row {
           label("Enter external libs to scan:")
         }
         row {
-          myExternalLibsField()
-        }
-      }
-      titledRow("Scan Everything? (WIP)") {
-        row {
-          myScanEverythingStatus()
+          myExternalLibsField().enableIf(myScanExplicitLibsStatus.selected)
         }
       }
     }.withBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10))

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginSettingsConfigurable.kt
@@ -28,20 +28,20 @@ class PluginSettingsConfigurable : Configurable {
   override fun isModified(): Boolean {
     val settings: PluginSettingsState = PluginSettingsState.instance
     var modified: Boolean = mySettingsComponent!!.externalLibsText != settings.externalLibs
-    modified = modified or (mySettingsComponent!!.scanEverythingStatus != settings.scanEveryThing)
+    modified = modified or (mySettingsComponent!!.scanExplicitLibsStatus != settings.scanExplicitLibs)
     return modified
   }
 
   override fun apply() {
     val settings: PluginSettingsState = PluginSettingsState.instance
     settings.externalLibs = mySettingsComponent!!.externalLibsText
-    settings.scanEveryThing = mySettingsComponent!!.scanEverythingStatus
+    settings.scanExplicitLibs = mySettingsComponent!!.scanExplicitLibsStatus
   }
 
   override fun reset() {
     val settings: PluginSettingsState = PluginSettingsState.instance
     mySettingsComponent!!.externalLibsText = settings.externalLibs
-    mySettingsComponent!!.scanEverythingStatus = settings.scanEveryThing
+    mySettingsComponent!!.scanExplicitLibsStatus = settings.scanExplicitLibs
   }
 
   override fun disposeUIResources() {

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginSettingsConfigurable.kt
@@ -28,7 +28,8 @@ class PluginSettingsConfigurable : Configurable {
   override fun isModified(): Boolean {
     val settings: PluginSettingsState = PluginSettingsState.instance
     var modified: Boolean = mySettingsComponent!!.externalLibsText != settings.externalLibs
-    modified = modified or (mySettingsComponent!!.scanExplicitLibsStatus != settings.scanExplicitLibs)
+    modified =
+      modified or (mySettingsComponent!!.scanExplicitLibsStatus != settings.scanExplicitLibs) or (mySettingsComponent!!.customSchematicsDirText != settings.customSchematicsLocation)
     return modified
   }
 
@@ -36,12 +37,14 @@ class PluginSettingsConfigurable : Configurable {
     val settings: PluginSettingsState = PluginSettingsState.instance
     settings.externalLibs = mySettingsComponent!!.externalLibsText
     settings.scanExplicitLibs = mySettingsComponent!!.scanExplicitLibsStatus
+    settings.customSchematicsLocation = mySettingsComponent!!.customSchematicsDirText
   }
 
   override fun reset() {
     val settings: PluginSettingsState = PluginSettingsState.instance
     mySettingsComponent!!.externalLibsText = settings.externalLibs
     mySettingsComponent!!.scanExplicitLibsStatus = settings.scanExplicitLibs
+    mySettingsComponent!!.customSchematicsDirText = settings.customSchematicsLocation
   }
 
   override fun disposeUIResources() {

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginSettingsConfigurable.kt
@@ -1,0 +1,50 @@
+package com.github.etkachev.nxwebstorm.ui.settings
+
+import com.intellij.openapi.options.Configurable
+import org.jetbrains.annotations.Nls
+import org.jetbrains.annotations.Nullable
+import javax.swing.JComponent
+
+class PluginSettingsConfigurable : Configurable {
+  private var mySettingsComponent: PluginSettingsComponent? = null
+
+  // A default constructor with no arguments is required because this implementation
+  // is registered as an applicationConfigurable EP
+  @Nls(capitalization = Nls.Capitalization.Title)
+  override fun getDisplayName(): String {
+    return "Nx Plugin Settings"
+  }
+
+  override fun getPreferredFocusedComponent(): JComponent {
+    return mySettingsComponent!!.preferredFocusedComponent
+  }
+
+  @Nullable
+  override fun createComponent(): JComponent? {
+    mySettingsComponent = PluginSettingsComponent()
+    return mySettingsComponent!!.panel
+  }
+
+  override fun isModified(): Boolean {
+    val settings: PluginSettingsState = PluginSettingsState.instance
+    var modified: Boolean = mySettingsComponent!!.externalLibsText != settings.externalLibs
+    modified = modified or (mySettingsComponent!!.scanEverythingStatus != settings.scanEveryThing)
+    return modified
+  }
+
+  override fun apply() {
+    val settings: PluginSettingsState = PluginSettingsState.instance
+    settings.externalLibs = mySettingsComponent!!.externalLibsText
+    settings.scanEveryThing = mySettingsComponent!!.scanEverythingStatus
+  }
+
+  override fun reset() {
+    val settings: PluginSettingsState = PluginSettingsState.instance
+    mySettingsComponent!!.externalLibsText = settings.externalLibs
+    mySettingsComponent!!.scanEverythingStatus = settings.scanEveryThing
+  }
+
+  override fun disposeUIResources() {
+    mySettingsComponent = null
+  }
+}

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginSettingsConfigurable.kt
@@ -27,22 +27,20 @@ class PluginSettingsConfigurable : Configurable {
 
   override fun isModified(): Boolean {
     val settings: PluginSettingsState = PluginSettingsState.instance
-    var modified: Boolean = mySettingsComponent!!.externalLibsText != settings.externalLibs
+    var modified: Boolean = mySettingsComponent!!.scanExplicitLibsStatus != settings.scanExplicitLibs
     modified =
-      modified or (mySettingsComponent!!.scanExplicitLibsStatus != settings.scanExplicitLibs) or (mySettingsComponent!!.customSchematicsDirText != settings.customSchematicsLocation)
+      modified or (mySettingsComponent!!.customSchematicsDirText != settings.customSchematicsLocation)
     return modified
   }
 
   override fun apply() {
     val settings: PluginSettingsState = PluginSettingsState.instance
-    settings.externalLibs = mySettingsComponent!!.externalLibsText
     settings.scanExplicitLibs = mySettingsComponent!!.scanExplicitLibsStatus
     settings.customSchematicsLocation = mySettingsComponent!!.customSchematicsDirText
   }
 
   override fun reset() {
     val settings: PluginSettingsState = PluginSettingsState.instance
-    mySettingsComponent!!.externalLibsText = settings.externalLibs
     mySettingsComponent!!.scanExplicitLibsStatus = settings.scanExplicitLibs
     mySettingsComponent!!.customSchematicsDirText = settings.customSchematicsLocation
   }

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginSettingsState.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginSettingsState.kt
@@ -26,7 +26,7 @@ class PluginSettingsState : PersistentStateComponent<PluginSettingsState?> {
     "@nestjs/schematics",
     "@ngrx/schematics"
   ).joinToString(", ")
-  var scanEveryThing = false
+  var scanExplicitLibs = true
 
   override fun getState(): PluginSettingsState? {
     return this

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginSettingsState.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginSettingsState.kt
@@ -1,0 +1,43 @@
+package com.github.etkachev.nxwebstorm.ui.settings
+
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.ServiceManager
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import com.intellij.util.xmlb.XmlSerializerUtil
+
+/**
+ * Supports storing the application settings in a persistent way.
+ * The State and Storage annotations define the name of the data and the file name where
+ * these persistent application settings are stored.
+ */
+@State(
+  name = "com.github.etkachev.nxwebstorm.ui.settings.PluginSettingsState",
+  storages = [Storage("NxPluginSettings.xml")]
+)
+class PluginSettingsState : PersistentStateComponent<PluginSettingsState?> {
+  var externalLibs = arrayOf(
+    "@nrwl/angular",
+    "@nrwl/nest",
+    "@nrwl/node",
+    "@nrwl/storybook",
+    "@nrwl/workspace",
+    "@schematics/angular",
+    "@nestjs/schematics",
+    "@ngrx/schematics"
+  ).joinToString(", ")
+  var scanEveryThing = false
+
+  override fun getState(): PluginSettingsState? {
+    return this
+  }
+
+  override fun loadState(state: PluginSettingsState) {
+    XmlSerializerUtil.copyBean(state, this)
+  }
+
+  companion object {
+    val instance: PluginSettingsState
+      get() = ServiceManager.getService(PluginSettingsState::class.java)
+  }
+}

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginSettingsState.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginSettingsState.kt
@@ -27,6 +27,7 @@ class PluginSettingsState : PersistentStateComponent<PluginSettingsState?> {
     "@ngrx/schematics"
   ).joinToString(", ")
   var scanExplicitLibs = true
+  var customSchematicLocation = "/tools/schematics"
 
   override fun getState(): PluginSettingsState? {
     return this

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginSettingsState.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginSettingsState.kt
@@ -27,7 +27,7 @@ class PluginSettingsState : PersistentStateComponent<PluginSettingsState?> {
     "@ngrx/schematics"
   ).joinToString(", ")
   var scanExplicitLibs = true
-  var customSchematicLocation = "/tools/schematics"
+  var customSchematicsLocation = "/tools/schematics"
 
   override fun getState(): PluginSettingsState? {
     return this

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/utils/ArrayUtils.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/utils/ArrayUtils.kt
@@ -1,0 +1,14 @@
+package com.github.etkachev.nxwebstorm.utils
+
+/**
+ * flatten array of maps into single map.
+ */
+fun <R, S> foldListOfMaps(maps: Array<Map<R, S>>): Map<R, S> {
+  return maps.fold(mutableMapOf<R, S>(), { acc, e ->
+    for (key in e.keys) {
+      val info = e[key] ?: continue
+      acc[key] = info
+    }
+    return@fold acc
+  }).toMap()
+}

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/utils/FindSchematics.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/utils/FindSchematics.kt
@@ -3,34 +3,27 @@ package com.github.etkachev.nxwebstorm.utils
 import com.github.etkachev.nxwebstorm.models.SchematicInfo
 import com.github.etkachev.nxwebstorm.ui.settings.PluginSettingsState
 import com.google.gson.JsonObject
+import com.google.gson.JsonParser
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.psi.PsiManager
+import com.intellij.psi.PsiFile
 import com.intellij.psi.search.FilenameIndex
 import com.intellij.psi.search.GlobalSearchScopes
 
 data class CollectionInfo(val json: JsonObject, val file: VirtualFile)
-data class PackageJsonInfo(val packageName: String, val json: JsonObject, val file: VirtualFile)
 class FindSchematics(private val project: Project, private val externalLibs: Array<String>) {
   var jsonFileReader = ReadFile(project)
+  var packageJsonHelper = PackageJsonHelper(project)
   var schematicPropName = "schematics"
   var nodeModulesFolder = "node_modules"
 
-  private fun getPackageFileInfo(directory: String): PackageJsonInfo? {
-    val packageFile = jsonFileReader.findVirtualFile("$nodeModulesFolder/$directory/package.json") ?: return null
-    return getPackageFileByVirtualFile(packageFile)
+  fun findByExternalLibs(): Map<String, SchematicInfo> {
+    val schematicMaps = externalLibs.mapNotNull { dir -> getSchematicsFromNodeModulesDirectory(dir) }
+    return foldListOfMaps(schematicMaps.toTypedArray())
   }
 
-  private fun getPackageFileByVirtualFile(file: VirtualFile): PackageJsonInfo? {
-    val packageFileJson = jsonFileReader.readJsonFromFile(file) ?: return null
-    val packageName = (if (packageFileJson.has("name")) packageFileJson["name"].asString else null) ?: return null
-    return PackageJsonInfo(packageName, packageFileJson, file)
-  }
-
-  private fun findAllPackageJsonFiles(): Map<String, SchematicInfo> {
-    val root = ProjectRootManager.getInstance(project).contentRoots[0]
-    val psiDir = PsiManager.getInstance(project).findDirectory(root) ?: return emptyMap()
+  fun scanAllForExternalSchematics(): Map<String, SchematicInfo> {
+    val psiDir = getRootPsiDirectory(project) ?: return emptyMap()
 
     val nodeModules = psiDir.findSubdirectory(nodeModulesFolder) ?: return emptyMap()
     val splitProjectRootPath = psiDir.virtualFile.path.split("/")
@@ -40,31 +33,56 @@ class FindSchematics(private val project: Project, private val externalLibs: Arr
       "package.json",
       GlobalSearchScopes.directoriesScope(project, true, nodeModules.virtualFile)
     ).mapNotNull { f ->
-      val (packageName, packageFileJson, packageFile) = getPackageFileByVirtualFile(f.virtualFile)
+      val (packageName, packageFileJson, packageFile) = packageJsonHelper.getPackageFileByVirtualFile(f.virtualFile)
         ?: return@mapNotNull null
       val (schematicsOptions, schematicCollection) = getSchematicOptions(packageFileJson, packageFile)
         ?: return@mapNotNull null
       val splitFullFileLocation = f.parent!!.virtualFile.path.split("$projectRootFolder/$nodeModulesFolder/")
       val nodeModulesFileLocation = splitFullFileLocation[1]
       val packageFileLocation = "$nodeModulesFolder/$nodeModulesFileLocation"
-      val schematicEntries =
-        schematicsOptions.entrySet().toTypedArray().fold(mutableMapOf<String, SchematicInfo>(), { acc, e ->
-          val value = e.value.asJsonObject
-          if (value.has("hidden") && value["hidden"].asBoolean) {
-            return@fold acc
-          }
-
-          val relativePath = getRelativePath(nodeModulesFileLocation, value, schematicCollection) ?: return@fold acc
-          val schematicsFileLocation = "$packageFileLocation$relativePath"
-          val id = generateUniqueSchematicKey(packageName, e.key)
-          val description = if (value.has("description")) value["description"].asString else null
-          acc[id] = SchematicInfo(schematicsFileLocation, description)
-          return@fold acc
-        })
-      val results = schematicEntries.toMap()
+      val results = getSchematicEntries(
+        schematicsOptions,
+        nodeModulesFileLocation,
+        schematicCollection,
+        packageName,
+        fileLocationMapper = { path -> "$packageFileLocation$path" })
       return@mapNotNull if (results.isNotEmpty()) results else null
     }.toTypedArray()
-    return foldListOfSchematicMaps(packageJsonFiles)
+    return foldListOfMaps(packageJsonFiles)
+  }
+
+  private fun getSchematicEntries(
+    schematicOptions: JsonObject,
+    directory: String,
+    schematicCollection: VirtualFile,
+    packageName: String,
+    fileLocationMapper: (path: String) -> String
+  ): Map<String, SchematicInfo> {
+    return schematicOptions.entrySet().toTypedArray().fold(mutableMapOf<String, SchematicInfo>(), { acc, e ->
+      val value = e.value.asJsonObject
+      if (value.has("hidden") && value["hidden"].asBoolean) {
+        return@fold acc
+      }
+
+      val relativePath = getRelativePath(directory, value, schematicCollection) ?: return@fold acc
+      val fileLocation = fileLocationMapper(relativePath)
+      val id = generateUniqueSchematicKey(packageName, e.key)
+      val description = if (value.has("description")) value["description"].asString else null
+      acc[id] = SchematicInfo(fileLocation, description)
+      return@fold acc
+    }).toMap()
+  }
+
+  private fun getSchematicsFromNodeModulesDirectory(directory: String): Map<String, SchematicInfo>? {
+    val packageJson = packageJsonHelper.getPackageFileInfo("$nodeModulesFolder/$directory") ?: return null
+    val (packageName, packageFileJson, packageFile) = packageJson
+    val (schematicsOptions, schematicCollection) = getSchematicOptions(packageFileJson, packageFile) ?: return null
+    return getSchematicEntries(
+      schematicsOptions,
+      directory,
+      schematicCollection,
+      packageName,
+      fileLocationMapper = { path -> "$nodeModulesFolder/$directory$path" })
   }
 
   private fun getSchematicOptions(packageFileJson: JsonObject, packageFile: VirtualFile): CollectionInfo? {
@@ -86,54 +104,27 @@ class FindSchematics(private val project: Project, private val externalLibs: Arr
     val splitFile = schemaFile.path.split(directory)
     return if (splitFile.count() == 2) splitFile[1] else null ?: return null
   }
-
-  private fun getSchematicsFromDirectory(directory: String): Map<String, SchematicInfo>? {
-    val packageJson = getPackageFileInfo(directory) ?: return null
-    val (packageName, packageFileJson, packageFile) = packageJson
-    val (schematicsOptions, schematicCollection) = getSchematicOptions(packageFileJson, packageFile) ?: return null
-    val schematicEntries =
-      schematicsOptions.entrySet().toTypedArray().fold(mutableMapOf<String, SchematicInfo>(), { acc, e ->
-        val value = e.value.asJsonObject
-        if (value.has("hidden") && value["hidden"].asBoolean) {
-          return@fold acc
-        }
-        val relativePath = getRelativePath(directory, value, schematicCollection) ?: return@fold acc
-        val fileLocation = "$nodeModulesFolder/$directory$relativePath"
-        val id = generateUniqueSchematicKey(packageName, e.key)
-        val description = if (value.has("description")) value["description"].asString else null
-        acc[id] = SchematicInfo(fileLocation, description)
-        return@fold acc
-      })
-
-    return schematicEntries.toMap()
-  }
-
-  fun findByExternalLibs(): Map<String, SchematicInfo> {
-    val schematicMaps = externalLibs.mapNotNull { dir -> getSchematicsFromDirectory(dir) }
-    return foldListOfSchematicMaps(schematicMaps.toTypedArray())
-  }
-
-  private fun foldListOfSchematicMaps(schematicMaps: Array<Map<String, SchematicInfo>>): Map<String, SchematicInfo> {
-    return schematicMaps.fold(mutableMapOf<String, SchematicInfo>(), { acc, e ->
-      for (key in e.keys) {
-        val info = e[key] ?: continue
-        acc[key] = info
-      }
-      return@fold acc
-    }).toMap()
-  }
-
-  fun scanAllForExternalSchematics(): Map<String, SchematicInfo> {
-    return findAllPackageJsonFiles()
-  }
 }
 
 class FindAllSchematics(private val project: Project) {
-  fun findAll(): Map<String, SchematicInfo> {
-    val customSchematics = GetNxData(project).getCustomSchematics()
+  var defaultToolsSchematicDir = "/tools/schematics"
+  var configToolsSchematicDir: String
+  private val cleanedUpConfigToolsSchematicDir: String
+    get() = if (configToolsSchematicDir.startsWith("/")) configToolsSchematicDir else "/$configToolsSchematicDir"
+  private val toolsSchematicDir: String
+    get() = if (configToolsSchematicDir.isBlank()) defaultToolsSchematicDir else cleanedUpConfigToolsSchematicDir
+  private val splitSchematicDir: Array<String>
+    get() = toolsSchematicDir.split("/").mapNotNull { s -> if (s.isBlank()) null else s }.toTypedArray()
+
+  init {
     val settings: PluginSettingsState = PluginSettingsState.instance
-    val findExplicitSchematics = settings.scanExplicitLibs
-    if (findExplicitSchematics) {
+    configToolsSchematicDir = settings.customSchematicLocation
+  }
+
+  fun findAll(): Map<String, SchematicInfo> {
+    val customSchematics = getCustomSchematics()
+    val settings: PluginSettingsState = PluginSettingsState.instance
+    if (settings.scanExplicitLibs) {
       val others = settings.externalLibs.split(",").mapNotNull { value ->
         val trimmed = value.trim()
         val final = if (trimmed.isEmpty()) null else trimmed
@@ -149,5 +140,27 @@ class FindAllSchematics(private val project: Project) {
       val allScanned = FindSchematics(project, emptyArray()).scanAllForExternalSchematics()
       return flattenMultipleMaps(customSchematics, allScanned)
     }
+  }
+
+  private fun getCustomSchematics(): Map<String, SchematicInfo> {
+    val rootPsiDirectory = getRootPsiDirectory(project)
+    val schematics = findPsiDirectoryBySplitFolders(splitSchematicDir, rootPsiDirectory) ?: return emptyMap()
+    val files = FilenameIndex.getFilesByName(
+      project, "schema.json",
+      GlobalSearchScopes.directoriesScope(project, true, schematics.virtualFile)
+    )
+    return files.mapNotNull { file -> getIdsFromSchema(file) }.toMap()
+  }
+
+  private fun getIdsFromSchema(file: PsiFile): Pair<String, SchematicInfo>? {
+    val json = JsonParser.parseString(file.text).asJsonObject ?: return null
+    if (!json.has("id")) {
+      return null
+    }
+    val id = json.get("id").asString
+    val fileLocation = "$toolsSchematicDir/$id/schema.json"
+    val info = SchematicInfo(fileLocation)
+    val uniqueId = generateUniqueSchematicKey("workspace-schematic", id)
+    return uniqueId to info
   }
 }

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/utils/FindSchematics.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/utils/FindSchematics.kt
@@ -118,7 +118,7 @@ class FindAllSchematics(private val project: Project) {
 
   init {
     val settings: PluginSettingsState = PluginSettingsState.instance
-    configToolsSchematicDir = settings.customSchematicLocation
+    configToolsSchematicDir = settings.customSchematicsLocation
   }
 
   fun findAll(): Map<String, SchematicInfo> {

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/utils/FindSchematics.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/utils/FindSchematics.kt
@@ -1,6 +1,7 @@
 package com.github.etkachev.nxwebstorm.utils
 
 import com.github.etkachev.nxwebstorm.models.SchematicInfo
+import com.github.etkachev.nxwebstorm.ui.settings.PluginSettingsState
 import com.google.gson.JsonObject
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
@@ -75,19 +76,16 @@ class FindSchematics(project: Project, private val externalLibs: Array<String>) 
 class FindAllSchematics(private val project: Project) {
   fun findAll(): Map<String, SchematicInfo> {
     val customSchematics = GetNxData().getCustomSchematics(project)
+    val settings: PluginSettingsState = PluginSettingsState.instance
+    val others = settings.externalLibs.split(",").mapNotNull { value ->
+      val trimmed = value.trim()
+      val final = if (trimmed.isEmpty()) null else trimmed
+      final
+    }
     val more =
       FindSchematics(
         project,
-        arrayOf(
-          "@nrwl/angular",
-          "@nrwl/nest",
-          "@nrwl/node",
-          "@nrwl/storybook",
-          "@nrwl/workspace",
-          "@schematics/angular",
-          "@nestjs/schematics",
-          "@ngrx/schematics"
-        )
+        others.toTypedArray()
       ).findByExternalLibs()
     return flattenMultipleMaps(customSchematics, more)
   }

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/utils/GetNxData.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/utils/GetNxData.kt
@@ -1,83 +1,14 @@
 package com.github.etkachev.nxwebstorm.utils
 
-import com.github.etkachev.nxwebstorm.models.SchematicInfo
-import com.github.etkachev.nxwebstorm.ui.settings.PluginSettingsState
 import com.google.gson.JsonObject
-import com.google.gson.JsonParser
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.roots.ProjectRootManager
-import com.intellij.psi.PsiDirectory
-import com.intellij.psi.PsiFile
-import com.intellij.psi.PsiManager
-import com.intellij.psi.search.FilenameIndex
-import com.intellij.psi.search.GlobalSearchScopes
 
 class GetNxData(private val project: Project) {
-  var defaultToolsSchematicDir = "/tools/schematics"
-  var configToolsSchematicDir: String
-  private val cleanedUpConfigToolsSchematicDir: String
-    get() = if (configToolsSchematicDir.startsWith("/")) configToolsSchematicDir else "/$configToolsSchematicDir"
-  private val toolsSchematicDir: String
-    get() = if (configToolsSchematicDir.isBlank()) defaultToolsSchematicDir else cleanedUpConfigToolsSchematicDir
-  private val splitSchematicDir: Array<String>
-    get() = toolsSchematicDir.split("/").mapNotNull { s -> if (s.isBlank()) null else s }.toTypedArray()
-
-  init {
-    val settings: PluginSettingsState = PluginSettingsState.instance
-    configToolsSchematicDir = settings.customSchematicLocation
-  }
-
   fun getProjects(): List<String> {
     val json = this.readNxJson() ?: return emptyList()
 
     val projects = json.getAsJsonObject("projects").keySet()
     return projects.toList()
-  }
-
-  fun getCustomSchematics(): Map<String, SchematicInfo> {
-    val root = ProjectRootManager.getInstance(project).contentRoots[0]
-    val rootPsiDirectory = PsiManager.getInstance(project).findDirectory(root)
-    val schematics = findPsiDirectoryBySplitFolders(splitSchematicDir, rootPsiDirectory) ?: return emptyMap()
-    val files = FilenameIndex.getFilesByName(
-      project, "schema.json",
-      GlobalSearchScopes.directoriesScope(project, true, schematics.virtualFile)
-    )
-    return files.mapNotNull { file -> getIdsFromSchema(file) }.toMap()
-  }
-
-  private fun findPsiDirectoryBySplitFolders(
-    dir: Array<String>,
-    rootPsiDirectory: PsiDirectory?,
-    dirIndex: Int = 0,
-    checkedDirectory: PsiDirectory? = null
-  ): PsiDirectory? {
-    if (dir.count() == 0 || rootPsiDirectory == null) {
-      return null
-    }
-
-    // if reached end of array, return currentDirectory
-    if (dirIndex == dir.count()) {
-      return checkedDirectory
-    }
-
-    val currentPsiDir = (if (dirIndex == 0) rootPsiDirectory else checkedDirectory) ?: return null
-
-    val currentDir = dir[dirIndex]
-    val subPsiDir = currentPsiDir.findSubdirectory(currentDir) ?: return null
-    return findPsiDirectoryBySplitFolders(dir, rootPsiDirectory, dirIndex + 1, subPsiDir)
-  }
-
-  private fun getIdsFromSchema(file: PsiFile): Pair<String, SchematicInfo>? {
-    val json = JsonParser.parseString(file.text).asJsonObject ?: return null
-    if (!json.has("id")) {
-      return null
-    }
-    val id = json.get("id").asString
-    // TODO need to find safer way to build file location.
-    val fileLocation = "$toolsSchematicDir/$id/schema.json"
-    val info = SchematicInfo(fileLocation)
-    val uniqueId = generateUniqueSchematicKey("workspace-schematic", id)
-    return uniqueId to info
   }
 
   fun isValidNxProject(): Boolean {

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/utils/GetNxData.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/utils/GetNxData.kt
@@ -1,32 +1,70 @@
 package com.github.etkachev.nxwebstorm.utils
 
 import com.github.etkachev.nxwebstorm.models.SchematicInfo
+import com.github.etkachev.nxwebstorm.ui.settings.PluginSettingsState
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.psi.PsiDirectory
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
 import com.intellij.psi.search.FilenameIndex
 import com.intellij.psi.search.GlobalSearchScopes
 
-class GetNxData {
-  fun getProjects(project: Project): List<String> {
-    val json = this.readNxJson(project) ?: return emptyList()
+class GetNxData(private val project: Project) {
+  var defaultToolsSchematicDir = "/tools/schematics"
+  var configToolsSchematicDir: String
+  var rootPsiDirectory: PsiDirectory?
+  private val cleanedUpConfigToolsSchematicDir: String
+    get() = if (configToolsSchematicDir.startsWith("/")) configToolsSchematicDir else "/$configToolsSchematicDir"
+  private val toolsSchematicDir: String
+    get() = if (configToolsSchematicDir.isBlank()) defaultToolsSchematicDir else cleanedUpConfigToolsSchematicDir
+  private val splitSchematicDir: Array<String>
+    get() = toolsSchematicDir.split("/").mapNotNull { s -> if (s.isBlank()) null else s }.toTypedArray()
+
+  init {
+    val settings: PluginSettingsState = PluginSettingsState.instance
+    configToolsSchematicDir = settings.customSchematicLocation
+    val root = ProjectRootManager.getInstance(project).contentRoots[0]
+    rootPsiDirectory = PsiManager.getInstance(project).findDirectory(root)
+  }
+
+  fun getProjects(): List<String> {
+    val json = this.readNxJson() ?: return emptyList()
 
     val projects = json.getAsJsonObject("projects").keySet()
     return projects.toList()
   }
 
-  fun getCustomSchematics(project: Project): Map<String, SchematicInfo> {
-    val root = ProjectRootManager.getInstance(project).contentRoots[0]
-    val psiDir = PsiManager.getInstance(project).findDirectory(root) ?: return emptyMap()
-    val schematics = psiDir.findSubdirectory("tools")!!.findSubdirectory("schematics") ?: return emptyMap()
+  fun getCustomSchematics(): Map<String, SchematicInfo> {
+    val schematics = findPsiDirectoryBySplitFolders(splitSchematicDir) ?: return emptyMap()
     val files = FilenameIndex.getFilesByName(
       project, "schema.json",
       GlobalSearchScopes.directoriesScope(project, true, schematics.virtualFile)
     )
     return files.mapNotNull { file -> getIdsFromSchema(file) }.toMap()
+  }
+
+  private fun findPsiDirectoryBySplitFolders(
+    dir: Array<String>,
+    dirIndex: Int = 0,
+    checkedDirectory: PsiDirectory? = null
+  ): PsiDirectory? {
+    if (dir.count() == 0 || rootPsiDirectory == null) {
+      return null
+    }
+
+    // if reached end of array, return currentDirectory
+    if (dirIndex == dir.count()) {
+      return checkedDirectory
+    }
+
+    val currentPsiDir = (if (dirIndex == 0) rootPsiDirectory else checkedDirectory) ?: return null
+
+    val currentDir = dir[dirIndex]
+    val subPsiDir = currentPsiDir.findSubdirectory(currentDir) ?: return null
+    return findPsiDirectoryBySplitFolders(dir, dirIndex + 1, subPsiDir)
   }
 
   private fun getIdsFromSchema(file: PsiFile): Pair<String, SchematicInfo>? {
@@ -36,17 +74,17 @@ class GetNxData {
     }
     val id = json.get("id").asString
     // TODO need to find safer way to build file location.
-    val fileLocation = "/tools/schematics/$id/schema.json"
+    val fileLocation = "$toolsSchematicDir/$id/schema.json"
     val info = SchematicInfo(fileLocation)
     val uniqueId = generateUniqueSchematicKey("workspace-schematic", id)
     return uniqueId to info
   }
 
-  fun isValidNxProject(project: Project): Boolean {
-    return readNxJson(project) != null
+  fun isValidNxProject(): Boolean {
+    return readNxJson() != null
   }
 
-  private fun readNxJson(project: Project): JsonObject? {
+  private fun readNxJson(): JsonObject? {
     return ReadFile(project).readJsonFromFileUrl("nx.json")
   }
 }

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/utils/PackageJsonHelper.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/utils/PackageJsonHelper.kt
@@ -1,0 +1,22 @@
+package com.github.etkachev.nxwebstorm.utils
+
+import com.google.gson.JsonObject
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+
+data class PackageJsonInfo(val packageName: String, val json: JsonObject, val file: VirtualFile)
+
+class PackageJsonHelper(project: Project) {
+  var jsonFileReader = ReadFile(project)
+
+  fun getPackageFileInfo(directory: String): PackageJsonInfo? {
+    val packageFile = jsonFileReader.findVirtualFile("$directory/package.json") ?: return null
+    return getPackageFileByVirtualFile(packageFile)
+  }
+
+  fun getPackageFileByVirtualFile(file: VirtualFile): PackageJsonInfo? {
+    val packageFileJson = jsonFileReader.readJsonFromFile(file) ?: return null
+    val packageName = (if (packageFileJson.has("name")) packageFileJson["name"].asString else null) ?: return null
+    return PackageJsonInfo(packageName, packageFileJson, file)
+  }
+}

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/utils/PsiUtils.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/utils/PsiUtils.kt
@@ -1,0 +1,37 @@
+package com.github.etkachev.nxwebstorm.utils
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.psi.PsiDirectory
+import com.intellij.psi.PsiManager
+
+fun getRootPsiDirectory(project: Project): PsiDirectory? {
+  val root = ProjectRootManager.getInstance(project).contentRoots[0]
+  return PsiManager.getInstance(project).findDirectory(root)
+}
+
+/**
+ * via recursion find the psi directory based on split directory array.
+ * example directory: "/node_modules/nrwl/angular" would be ["node_modules", "nrwl", "angular"]
+ */
+fun findPsiDirectoryBySplitFolders(
+  dir: Array<String>,
+  rootPsiDirectory: PsiDirectory?,
+  dirIndex: Int = 0,
+  checkedDirectory: PsiDirectory? = null
+): PsiDirectory? {
+  if (dir.count() == 0 || rootPsiDirectory == null) {
+    return null
+  }
+
+  // if reached end of array, return currentDirectory
+  if (dirIndex == dir.count()) {
+    return checkedDirectory
+  }
+
+  val currentPsiDir = (if (dirIndex == 0) rootPsiDirectory else checkedDirectory) ?: return null
+
+  val currentDir = dir[dirIndex]
+  val subPsiDir = currentPsiDir.findSubdirectory(currentDir) ?: return null
+  return findPsiDirectoryBySplitFolders(dir, rootPsiDirectory, dirIndex + 1, subPsiDir)
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -19,8 +19,14 @@
                     factoryClass="com.github.etkachev.nxwebstorm.ui.GenerateToolWindow"/>
         <applicationConfigurable parentId="tools"
                                  instance="com.github.etkachev.nxwebstorm.ui.settings.PluginSettingsConfigurable"
+                                 nonDefaultProject="true"
                                  id="com.github.etkachev.nxwebstorm.ui.settings.PluginSettingsConfigurable"
-                                 displayName="Nx Plugin Settings"/>
+                                 displayName="Nx Plugin Settings">
+            <configurable nonDefaultProject="true"
+                          id="com.github.etkachev.nxwebstorm.ui.settings.ExternalSchematicsSettingsConfigurable"
+                          instance="com.github.etkachev.nxwebstorm.ui.settings.ExternalSchematicsSettingsConfigurable"
+                          displayName="External Schematics"/>
+        </applicationConfigurable>
     </extensions>
 
     <projectListeners>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -13,9 +13,14 @@
 
     <extensions defaultExtensionNs="com.intellij">
         <applicationService serviceImplementation="com.github.etkachev.nxwebstorm.services.MyApplicationService"/>
+        <applicationService serviceImplementation="com.github.etkachev.nxwebstorm.ui.settings.PluginSettingsState"/>
         <projectService serviceImplementation="com.github.etkachev.nxwebstorm.services.MyProjectService"/>
         <toolWindow id="Nx" anchor="right"
                     factoryClass="com.github.etkachev.nxwebstorm.ui.GenerateToolWindow"/>
+        <applicationConfigurable parentId="tools"
+                                 instance="com.github.etkachev.nxwebstorm.ui.settings.PluginSettingsConfigurable"
+                                 id="com.github.etkachev.nxwebstorm.ui.settings.PluginSettingsConfigurable"
+                                 displayName="Nx Plugin Settings"/>
     </extensions>
 
     <projectListeners>


### PR DESCRIPTION
## Current Behavior

<!-- The behavior we have today before this PR is merged -->
* We did not have any plugin settings

## Expected Behavior

<!-- The behavior we will have after the PR is merged -->
We now have plugin settings with following configurables:
* Toggle whether to scan only explicit external libraries for schematics (faster) or do full scan of node_modules (slower)
* Specify external libraries to scan (if above is toggled on)
* configure location of custom schematics (by default its `/tools/schematics`)

## Motivation

<!-- Why is this behavior expected? -->
Start of being able to configure the plugin

## Related Issue

<!-- Please link an issue from github -->
<!-- that may provide more information regarding this PR -->
CLOSES #18 

## Additional Notes

<!-- ... -->
