### PR TITLE
chore: increasing minor version of plugin for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,16 +19,9 @@
 ### Added
 - Added mechanism to refresh list of schematics. Should be a button next to the search bar on panel showing list of schematics.
 
-### Changed
-
-### Deprecated
-
-### Removed
-
 ### Fixed
 - If shell tab is still executing commands, do not try to run commands again. 
 
-### Security
 ## [0.2.0]
 ### Changed
 - When running nx commands, use local installed nx cli instead of global

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # -> https://www.jetbrains.org/intellij/sdk/docs/reference_guide/intellij_artifacts.html
 pluginGroup=com.github.etkachev.nxwebstorm
 pluginName=nx-webstorm
-pluginVersion=0.2.1
+pluginVersion=0.3.0
 pluginSinceBuild=202
 pluginUntilBuild=202.*
 platformType=IU


### PR DESCRIPTION
## Current Behavior

<!-- The behavior we have today before this PR is merged -->
version is at 0.2.1

## Expected Behavior

<!-- The behavior we will have after the PR is merged -->
Increase to next minor version 0.3.0

## Motivation

<!-- Why is this behavior expected? -->
Preparing next release

## Related Issue

<!-- Please link an issue from github -->
<!-- that may provide more information regarding this PR -->

## Additional Notes

<!-- ... -->
