### PR TITLE
feat: nrwl icon and settings migration

### DIFF
--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/GenerateToolWindow.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/GenerateToolWindow.kt
@@ -6,10 +6,12 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
 import com.intellij.ui.content.ContentFactory
+import icons.PluginIcons
 
 class GenerateToolWindow : ToolWindowFactory {
   private var tabName = "Generate"
   override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
+    toolWindow.setIcon(PluginIcons.NRWL_ICON)
     val contentFactory = ContentFactory.SERVICE.getInstance()
     val schematicFetcher = FindAllSchematics(project)
     val allSchematics = schematicFetcher.findAll()

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/ExternalSchematicsSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/ExternalSchematicsSettingsConfigurable.kt
@@ -1,9 +1,10 @@
 package com.github.etkachev.nxwebstorm.ui.settings
 
 import com.intellij.openapi.options.Configurable
+import com.intellij.openapi.project.Project
 import javax.swing.JComponent
 
-class ExternalSchematicsSettingsConfigurable : Configurable {
+class ExternalSchematicsSettingsConfigurable(val project: Project) : Configurable {
   private var externalSchematicsComponent: ExternalSchematicsSettingsComponent? = null
 
   override fun createComponent(): JComponent? {
@@ -12,15 +13,15 @@ class ExternalSchematicsSettingsConfigurable : Configurable {
   }
 
   override fun isModified(): Boolean {
-    val settings: PluginSettingsState = PluginSettingsState.instance
-    val current = settings.externalLibs
+    val settings: PluginProjectSettingsState = PluginProjectSettingsState.getInstance(this.project)
+    val current = settings.externalLibs.joinToString(",")
     val newList = externalSchematicsComponent!!.externalSchematics.joinToString(",")
     return newList != current
   }
 
   override fun apply() {
-    val settings: PluginSettingsState = PluginSettingsState.instance
-    settings.externalLibs = externalSchematicsComponent!!.externalSchematics.joinToString(",")
+    val settings: PluginProjectSettingsState = PluginProjectSettingsState.getInstance(this.project)
+    settings.externalLibs = externalSchematicsComponent!!.externalSchematics
   }
 
   override fun getPreferredFocusedComponent(): JComponent {
@@ -32,8 +33,8 @@ class ExternalSchematicsSettingsConfigurable : Configurable {
   }
 
   override fun reset() {
-    val settings: PluginSettingsState = PluginSettingsState.instance
-    externalSchematicsComponent!!.externalSchematics = settings.externalLibs.split(",").toTypedArray()
+    val settings: PluginProjectSettingsState = PluginProjectSettingsState.getInstance(this.project)
+    externalSchematicsComponent!!.externalSchematics = settings.externalLibs
   }
 
   override fun disposeUIResources() {

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginProjectSettingsState.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginProjectSettingsState.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
+import com.intellij.openapi.project.Project
 import com.intellij.util.xmlb.XmlSerializerUtil
 
 /**
@@ -12,23 +13,13 @@ import com.intellij.util.xmlb.XmlSerializerUtil
  * these persistent application settings are stored.
  */
 @State(
-  name = "com.github.etkachev.nxwebstorm.ui.settings.PluginSettingsState",
+  name = "com.github.etkachev.nxwebstorm.ui.settings.PluginProjectSettingsState",
   storages = [Storage("NxPluginProjectSettings.xml")]
 )
 class PluginProjectSettingsState : PersistentStateComponent<PluginProjectSettingsState?> {
-  var nodeModulesFolder = "node_modules"
-  var externalLibs = arrayOf(
-    "$nodeModulesFolder/@nrwl/angular",
-    "$nodeModulesFolder/@nrwl/nest",
-    "$nodeModulesFolder/@nrwl/node",
-    "$nodeModulesFolder/@nrwl/storybook",
-    "$nodeModulesFolder/@nrwl/workspace",
-    "$nodeModulesFolder/@schematics/angular",
-    "$nodeModulesFolder/@nestjs/schematics",
-    "$nodeModulesFolder/@ngrx/schematics"
-  )
-  var scanExplicitLibs = true
-  var customSchematicsLocation = "/tools/schematics"
+  var externalLibs = PluginSettingsState.instance.externalLibs.split(",").toTypedArray()
+  var scanExplicitLibs = PluginSettingsState.instance.scanExplicitLibs
+  var customSchematicsLocation = PluginSettingsState.instance.customSchematicsLocation
 
   override fun getState(): PluginProjectSettingsState? {
     return this
@@ -39,7 +30,10 @@ class PluginProjectSettingsState : PersistentStateComponent<PluginProjectSetting
   }
 
   companion object {
-    val instance: PluginProjectSettingsState
-      get() = ServiceManager.getService(PluginProjectSettingsState::class.java)
+    fun getInstance(project: Project): PluginProjectSettingsState {
+      return ServiceManager.getService(project, PluginProjectSettingsState::class.java)
+    }
+    // val instance: PluginProjectSettingsState
+    //   get() = project.getService(PluginProjectSettingsState::class.java)
   }
 }

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginProjectSettingsState.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginProjectSettingsState.kt
@@ -33,7 +33,5 @@ class PluginProjectSettingsState : PersistentStateComponent<PluginProjectSetting
     fun getInstance(project: Project): PluginProjectSettingsState {
       return ServiceManager.getService(project, PluginProjectSettingsState::class.java)
     }
-    // val instance: PluginProjectSettingsState
-    //   get() = project.getService(PluginProjectSettingsState::class.java)
   }
 }

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginProjectSettingsState.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginProjectSettingsState.kt
@@ -1,0 +1,45 @@
+package com.github.etkachev.nxwebstorm.ui.settings
+
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.ServiceManager
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import com.intellij.util.xmlb.XmlSerializerUtil
+
+/**
+ * Supports storing the application settings in a persistent way.
+ * The State and Storage annotations define the name of the data and the file name where
+ * these persistent application settings are stored.
+ */
+@State(
+  name = "com.github.etkachev.nxwebstorm.ui.settings.PluginSettingsState",
+  storages = [Storage("NxPluginProjectSettings.xml")]
+)
+class PluginProjectSettingsState : PersistentStateComponent<PluginProjectSettingsState?> {
+  var nodeModulesFolder = "node_modules"
+  var externalLibs = arrayOf(
+    "$nodeModulesFolder/@nrwl/angular",
+    "$nodeModulesFolder/@nrwl/nest",
+    "$nodeModulesFolder/@nrwl/node",
+    "$nodeModulesFolder/@nrwl/storybook",
+    "$nodeModulesFolder/@nrwl/workspace",
+    "$nodeModulesFolder/@schematics/angular",
+    "$nodeModulesFolder/@nestjs/schematics",
+    "$nodeModulesFolder/@ngrx/schematics"
+  )
+  var scanExplicitLibs = true
+  var customSchematicsLocation = "/tools/schematics"
+
+  override fun getState(): PluginProjectSettingsState? {
+    return this
+  }
+
+  override fun loadState(state: PluginProjectSettingsState) {
+    XmlSerializerUtil.copyBean(state, this)
+  }
+
+  companion object {
+    val instance: PluginProjectSettingsState
+      get() = ServiceManager.getService(PluginProjectSettingsState::class.java)
+  }
+}

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginSettingsComponent.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginSettingsComponent.kt
@@ -1,6 +1,5 @@
 package com.github.etkachev.nxwebstorm.ui.settings
 
-import com.intellij.ui.CollectionListModel
 import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.components.JBTextField
 import javax.swing.JComponent
@@ -15,7 +14,6 @@ class PluginSettingsComponent {
   val panel: JPanel
   private val myScanExplicitLibsStatus: JBCheckBox
   private val myCustomSchematicsDirectory: JBTextField = JBTextField()
-  private val myExternalLibsList: CollectionListModel<String>
 
   val preferredFocusedComponent: JComponent
     get() = myScanExplicitLibsStatus
@@ -33,11 +31,10 @@ class PluginSettingsComponent {
   init {
     val checkBox =
       JBCheckBox(
-        "Scan only explicit external libs (faster). " +
+        "Scan explicit external libs (faster). " +
           "If off, it will scan all of node_modules (slower)."
       )
     myScanExplicitLibsStatus = checkBox
-    myExternalLibsList = CollectionListModel()
 
     panel = panel {
       titledRow("Scan Explicit External Libs?") {

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginSettingsConfigurable.kt
@@ -1,11 +1,12 @@
 package com.github.etkachev.nxwebstorm.ui.settings
 
 import com.intellij.openapi.options.Configurable
+import com.intellij.openapi.project.Project
 import org.jetbrains.annotations.Nls
 import org.jetbrains.annotations.Nullable
 import javax.swing.JComponent
 
-class PluginSettingsConfigurable : Configurable {
+class PluginSettingsConfigurable(val project: Project) : Configurable {
   private var mySettingsComponent: PluginSettingsComponent? = null
 
   // A default constructor with no arguments is required because this implementation
@@ -26,7 +27,7 @@ class PluginSettingsConfigurable : Configurable {
   }
 
   override fun isModified(): Boolean {
-    val settings: PluginSettingsState = PluginSettingsState.instance
+    val settings: PluginProjectSettingsState = PluginProjectSettingsState.getInstance(this.project)
     var modified: Boolean = mySettingsComponent!!.scanExplicitLibsStatus != settings.scanExplicitLibs
     modified =
       modified or (mySettingsComponent!!.customSchematicsDirText != settings.customSchematicsLocation)
@@ -34,13 +35,13 @@ class PluginSettingsConfigurable : Configurable {
   }
 
   override fun apply() {
-    val settings: PluginSettingsState = PluginSettingsState.instance
+    val settings: PluginProjectSettingsState = PluginProjectSettingsState.getInstance(this.project)
     settings.scanExplicitLibs = mySettingsComponent!!.scanExplicitLibsStatus
     settings.customSchematicsLocation = mySettingsComponent!!.customSchematicsDirText
   }
 
   override fun reset() {
-    val settings: PluginSettingsState = PluginSettingsState.instance
+    val settings: PluginProjectSettingsState = PluginProjectSettingsState.getInstance(this.project)
     mySettingsComponent!!.scanExplicitLibsStatus = settings.scanExplicitLibs
     mySettingsComponent!!.customSchematicsDirText = settings.customSchematicsLocation
   }

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/utils/FindSchematics.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/utils/FindSchematics.kt
@@ -1,7 +1,7 @@
 package com.github.etkachev.nxwebstorm.utils
 
 import com.github.etkachev.nxwebstorm.models.SchematicInfo
-import com.github.etkachev.nxwebstorm.ui.settings.PluginSettingsState
+import com.github.etkachev.nxwebstorm.ui.settings.PluginProjectSettingsState
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import com.intellij.openapi.project.Project
@@ -117,15 +117,15 @@ class FindAllSchematics(private val project: Project) {
     get() = toolsSchematicDir.split("/").mapNotNull { s -> if (s.isBlank()) null else s }.toTypedArray()
 
   init {
-    val settings: PluginSettingsState = PluginSettingsState.instance
+    val settings: PluginProjectSettingsState = PluginProjectSettingsState.getInstance(project)
     configToolsSchematicDir = settings.customSchematicsLocation
   }
 
   fun findAll(): Map<String, SchematicInfo> {
     val customSchematics = getCustomSchematics()
-    val settings: PluginSettingsState = PluginSettingsState.instance
+    val settings: PluginProjectSettingsState = PluginProjectSettingsState.getInstance(project)
     if (settings.scanExplicitLibs) {
-      val others = settings.externalLibs.split(",").mapNotNull { value ->
+      val others = settings.externalLibs.mapNotNull { value ->
         val trimmed = value.trim()
         val final = if (trimmed.isEmpty()) null else trimmed
         final

--- a/src/main/kotlin/icons/PluginIcons.java
+++ b/src/main/kotlin/icons/PluginIcons.java
@@ -1,9 +1,0 @@
-package icons;
-
-import com.intellij.openapi.util.IconLoader;
-
-import javax.swing.*;
-
-public interface PluginIcons {
-    Icon NRWL_ICON = IconLoader.getIcon("/icons/nrwl.svg");
-}

--- a/src/main/kotlin/icons/PluginIcons.kt
+++ b/src/main/kotlin/icons/PluginIcons.kt
@@ -1,0 +1,7 @@
+package icons
+
+import com.intellij.openapi.util.IconLoader
+
+object PluginIcons {
+  val NRWL_ICON = IconLoader.getIcon("/icons/nrwl.svg")
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -14,19 +14,20 @@
     <extensions defaultExtensionNs="com.intellij">
         <applicationService serviceImplementation="com.github.etkachev.nxwebstorm.services.MyApplicationService"/>
         <applicationService serviceImplementation="com.github.etkachev.nxwebstorm.ui.settings.PluginSettingsState"/>
+        <projectService serviceImplementation="com.github.etkachev.nxwebstorm.ui.settings.PluginProjectSettingsState"/>
         <projectService serviceImplementation="com.github.etkachev.nxwebstorm.services.MyProjectService"/>
         <toolWindow id="Nx" anchor="right"
                     factoryClass="com.github.etkachev.nxwebstorm.ui.GenerateToolWindow"/>
-        <applicationConfigurable parentId="tools"
-                                 instance="com.github.etkachev.nxwebstorm.ui.settings.PluginSettingsConfigurable"
-                                 nonDefaultProject="true"
-                                 id="com.github.etkachev.nxwebstorm.ui.settings.PluginSettingsConfigurable"
-                                 displayName="Nx Plugin Settings">
+        <projectConfigurable parentId="tools"
+                             instance="com.github.etkachev.nxwebstorm.ui.settings.PluginSettingsConfigurable"
+                             nonDefaultProject="true"
+                             id="com.github.etkachev.nxwebstorm.ui.settings.PluginSettingsConfigurable"
+                             displayName="Nx Plugin Settings">
             <configurable nonDefaultProject="true"
                           id="com.github.etkachev.nxwebstorm.ui.settings.ExternalSchematicsSettingsConfigurable"
                           instance="com.github.etkachev.nxwebstorm.ui.settings.ExternalSchematicsSettingsConfigurable"
                           displayName="External Schematics"/>
-        </applicationConfigurable>
+        </projectConfigurable>
     </extensions>
 
     <projectListeners>


### PR DESCRIPTION
## Current Behavior

<!-- The behavior we have today before this PR is merged -->
* Settings for plugin are currently set as application level (global settings)
* No icon rendered for Nx tool tab

## Expected Behavior

<!-- The behavior we will have after the PR is merged -->
* Move settings for plugin to be project level
* New icon rendering for Nx tool tab.

## Motivation

<!-- Why is this behavior expected? -->
* Made more sense to have settings flexible per project.

## Related Issue

<!-- Please link an issue from github -->
<!-- that may provide more information regarding this PR -->

## Additional Notes

<!-- ... -->
