### PR TITLE
chore: upping version and updating changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,13 @@
 
 ## [Unreleased]
 ### Added
+- Nrwl icon added to Nx tool tab
+- Added autocomplete dropdown to show list of projects to choose from. 
+This is for schematic properties that have `$default.$source` set to `projectName`.
 
 ### Changed
+- Plugin Settings are transferred to be project settings instead of application settings.
+- Some general refactor and performance tweaks
 
 ### Deprecated
 
@@ -18,15 +23,6 @@
 ### Added
 - Added settings to configure plugin. Be able to configure things such as external packages to scan for schematics, and configuring location of custom schematics.
 
-### Changed
-
-### Deprecated
-
-### Removed
-
-### Fixed
-
-### Security
 ## [0.2.1]
 ### Added
 - Added mechanism to refresh list of schematics. Should be a button next to the search bar on panel showing list of schematics.

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # -> https://www.jetbrains.org/intellij/sdk/docs/reference_guide/intellij_artifacts.html
 pluginGroup=com.github.etkachev.nxwebstorm
 pluginName=nx-webstorm
-pluginVersion=0.3.0
+pluginVersion=0.4.0
 pluginSinceBuild=202
 pluginUntilBuild=202.*
 platformType=IU


### PR DESCRIPTION
## Current Behavior

<!-- The behavior we have today before this PR is merged -->
* Changelog is outdated.
* plugin version is 0.3.0

## Expected Behavior

<!-- The behavior we will have after the PR is merged -->
* Updated changelog to include latest
* update plugin version to 0.4.0

## Motivation

<!-- Why is this behavior expected? -->
Prepare release

## Related Issue

<!-- Please link an issue from github -->
<!-- that may provide more information regarding this PR -->

## Additional Notes

<!-- ... -->
