### PR TITLE
chore: updated pluginUntilBuild to latest 203 with latest webstorm update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Removed
 
 ### Fixed
+- update `pluginUntilBuild` to latest 203.* to handle latest webstorm update
 
 ### Security
 ## [0.6.0]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,7 +83,7 @@ tasks {
 
   runIde {
     setIdeDirectory(
-      "/Users/edwardtkachev/Library/Application Support/JetBrains/Toolbox/apps/WebStorm/ch-0/202.7660.23/WebStorm.app/Contents"
+      "/Users/edwardtkachev/Library/Application Support/JetBrains/Toolbox/apps/WebStorm/ch-0/203.5981.135/WebStorm.app/Contents"
     )
   }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,9 +2,9 @@
 # -> https://www.jetbrains.org/intellij/sdk/docs/reference_guide/intellij_artifacts.html
 pluginGroup=com.github.etkachev.nxwebstorm
 pluginName=nx-webstorm
-pluginVersion=0.6.0
+pluginVersion=0.6.1
 pluginSinceBuild=202
-pluginUntilBuild=202.*
+pluginUntilBuild=203.*
 platformType=IU
 platformVersion=2020.2
 platformDownloadSources=true


### PR DESCRIPTION
## Current Behavior

<!-- The behavior we have today before this PR is merged -->
- `pluginUntilBuild` was set to 202.*

## Expected Behavior

<!-- The behavior we will have after the PR is merged -->
- `pluginUntilBuild` should be set to latest 203.*

## Motivation

<!-- Why is this behavior expected? -->
New version of Webstorm came out

## Related Issue

<!-- Please link an issue from github -->
<!-- that may provide more information regarding this PR -->

## Additional Notes

<!-- ... -->
