### PR TITLE
feat: updated defaults for custom schematics dir depending on nx cli version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changed
 
+- Updated default directory for custom schematics with Nx 11
 - Updated gradle configs and ymls to latest plugin template 0.7.1
 
 ### Deprecated
@@ -20,19 +21,9 @@
 
 ## [0.6.1]
 
-### Added
-
-### Changed
-
-### Deprecated
-
-### Removed
-
 ### Fixed
 
 - update `pluginUntilBuild` to latest 203.* to handle latest webstorm update
-
-### Security
 
 ## [0.6.0]
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # -> https://www.jetbrains.org/intellij/sdk/docs/reference_guide/intellij_artifacts.html
 pluginGroup=com.github.etkachev.nxwebstorm
 pluginName_=nx-webstorm
-pluginVersion=0.6.2
+pluginVersion=0.7.0
 pluginSinceBuild=202
 pluginUntilBuild=203.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/services/MyProjectService.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/services/MyProjectService.kt
@@ -8,13 +8,17 @@ import com.intellij.openapi.project.Project
 import com.github.etkachev.nxwebstorm.utils.ReadFile
 import com.google.gson.JsonObject
 import com.intellij.javascript.nodejs.interpreter.NodeJsInterpreterManager
+import com.intellij.javascript.nodejs.packageJson.NodeInstalledPackageFinder
 import com.intellij.javascript.nodejs.settings.NodeInstalledPackage
 import com.intellij.javascript.nodejs.settings.NodePackageManagementService
+import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.util.text.SemVer
 
 class MyProjectService(private val project: Project) {
   private var readFile = ReadFile.getInstance(project)
   private var schematicsCliDir: String? = null
+  private var projectRoot = ProjectRootManager.getInstance(project).contentRoots[0]
   val schematicsCliDirectory: String?
     get() = this.schematicsCliDir
   val nxJson: JsonObject?
@@ -26,6 +30,15 @@ class MyProjectService(private val project: Project) {
       val thisProject = this.project
       return thisProject.basePath
     }
+
+  private val nxCliVersion: SemVer?
+    get() = NodeInstalledPackageFinder(this.project, this.projectRoot).findInstalledPackage("@nrwl/cli")?.version
+
+  private val isNx11OrAbove: Boolean
+    get() = this.nxCliVersion != null && this.nxCliVersion!!.major >= 11
+
+  val defaultCustomSchematicsLocation: String
+    get() = if (this.isNx11OrAbove) "/tools/generators" else "/tools/schematics"
 
   /**
    * full list of projects/libraries within current project.

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/ExternalSchematicsSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/ExternalSchematicsSettingsConfigurable.kt
@@ -14,8 +14,8 @@ class ExternalSchematicsSettingsConfigurable(val project: Project) : Configurabl
 
   override fun isModified(): Boolean {
     val settings: PluginProjectSettingsState = PluginProjectSettingsState.getInstance(this.project)
-    val current = settings.externalLibs.joinToString(",")
-    val newList = externalSchematicsComponent!!.externalSchematics.joinToString(",")
+    val current = settings.externalLibs.joinToString(",") { l -> l.trim() }
+    val newList = externalSchematicsComponent!!.externalSchematics.joinToString(",") { l -> l.trim() }
     return newList != current
   }
 

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginProjectSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginProjectSettingsConfigurable.kt
@@ -30,8 +30,10 @@ class PluginProjectSettingsConfigurable(val project: Project) : Configurable {
   override fun isModified(): Boolean {
     val settings: PluginProjectSettingsState = PluginProjectSettingsState.getInstance(this.project)
     var modified: Boolean = mySettingsComponent!!.scanExplicitLibsStatus != settings.scanExplicitLibs
-    modified =
-      modified or (mySettingsComponent!!.customSchematicsDirText != settings.customSchematicsLocation && settings.customSchematicsLocation != null)
+    val settingCustomSchemDir = settings.customSchematicsLocation
+    val componentSchematicText = mySettingsComponent!!.customSchematicsDirText
+    modified = modified or
+      (componentSchematicText != settingCustomSchemDir && settingCustomSchemDir != null)
     return modified
   }
 

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginProjectSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginProjectSettingsConfigurable.kt
@@ -1,5 +1,6 @@
 package com.github.etkachev.nxwebstorm.ui.settings
 
+import com.github.etkachev.nxwebstorm.services.MyProjectService
 import com.intellij.openapi.options.Configurable
 import com.intellij.openapi.project.Project
 import org.jetbrains.annotations.Nls
@@ -30,7 +31,7 @@ class PluginProjectSettingsConfigurable(val project: Project) : Configurable {
     val settings: PluginProjectSettingsState = PluginProjectSettingsState.getInstance(this.project)
     var modified: Boolean = mySettingsComponent!!.scanExplicitLibsStatus != settings.scanExplicitLibs
     modified =
-      modified or (mySettingsComponent!!.customSchematicsDirText != settings.customSchematicsLocation)
+      modified or (mySettingsComponent!!.customSchematicsDirText != settings.customSchematicsLocation && settings.customSchematicsLocation != null)
     return modified
   }
 
@@ -42,8 +43,10 @@ class PluginProjectSettingsConfigurable(val project: Project) : Configurable {
 
   override fun reset() {
     val settings: PluginProjectSettingsState = PluginProjectSettingsState.getInstance(this.project)
+    val projService = MyProjectService.getInstance(this.project)
     mySettingsComponent!!.scanExplicitLibsStatus = settings.scanExplicitLibs
-    mySettingsComponent!!.customSchematicsDirText = settings.customSchematicsLocation
+    mySettingsComponent!!.customSchematicsDirText =
+      settings.customSchematicsLocation ?: projService.defaultCustomSchematicsLocation
   }
 
   override fun disposeUIResources() {

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginProjectSettingsState.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginProjectSettingsState.kt
@@ -19,9 +19,9 @@ import com.intellij.util.xmlb.XmlSerializerUtil
 class PluginProjectSettingsState : PersistentStateComponent<PluginProjectSettingsState?> {
   var externalLibs = PluginSettingsState.instance.externalLibs.split(",").toTypedArray()
   var scanExplicitLibs = PluginSettingsState.instance.scanExplicitLibs
-  var customSchematicsLocation = PluginSettingsState.instance.customSchematicsLocation
+  var customSchematicsLocation: String? = null
 
-  override fun getState(): PluginProjectSettingsState? {
+  override fun getState(): PluginProjectSettingsState {
     return this
   }
 

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/utils/FindSchematics.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/utils/FindSchematics.kt
@@ -22,9 +22,9 @@ data class CollectionInfo(val json: JsonObject, val file: VirtualFile, val relat
  */
 class FindAllSchematics(private val project: Project) {
   private val projectSettings = PluginProjectSettingsState.getInstance(project)
-  private val defaultToolsSchematicDir = "/tools/schematics"
+  private val defaultToolsSchematicDir = MyProjectService.getInstance(this.project).defaultCustomSchematicsLocation
   private val configToolsSchematicDir: String
-    get() = projectSettings.customSchematicsLocation
+    get() = projectSettings.customSchematicsLocation ?: this.defaultToolsSchematicDir
   private val jsonFileReader = ReadFile.getInstance(project)
   private val packageJsonHelper = PackageJsonHelper(project)
   private val schematicPropName = "schematics"


### PR DESCRIPTION
## Current Behavior

<!-- The behavior we have today before this PR is merged -->
- default directory for custom schematics are set to `/tools/schematics`

## Expected Behavior

<!-- The behavior we will have after the PR is merged -->
- With Nx 11, default is now `/tools/generators`.
  - Depending on nx version (>= 11) set default directory for custom schematics

## Motivation

<!-- Why is this behavior expected? -->
- updated nx version

## Related Issue

<!-- Please link an issue from github -->
<!-- that may provide more information regarding this PR -->

## Additional Notes

<!-- ... -->
