### PR TITLE
chore: update to latest plugin template 0.8.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Dependabot configuration:
+# https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.run/Run IDE with Plugin.run.xml
+++ b/.run/Run IDE with Plugin.run.xml
@@ -1,5 +1,6 @@
 <component name="ProjectRunConfigurationManager">
     <configuration default="false" name="Run Plugin" type="GradleRunConfiguration" factoryName="Gradle">
+        <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea.log"/>
         <ExternalSystemSettings>
             <option name="executionName"/>
             <option name="externalProjectPath" value="$PROJECT_DIR$"/>

--- a/.run/Run Plugin Tests.run.xml
+++ b/.run/Run Plugin Tests.run.xml
@@ -1,21 +1,22 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Run Tests" type="GradleRunConfiguration" factoryName="Gradle">
-    <ExternalSystemSettings>
-      <option name="executionName" />
-      <option name="externalProjectPath" value="$PROJECT_DIR$" />
-      <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="--stacktrace" />
-      <option name="taskDescriptions">
-        <list />
-      </option>
-      <option name="taskNames">
-        <list>
-          <option value="check" />
-        </list>
-      </option>
-      <option name="vmOptions" value="" />
-    </ExternalSystemSettings>
-    <GradleScriptDebugEnabled>true</GradleScriptDebugEnabled>
-    <method v="2" />
-  </configuration>
+    <configuration default="false" name="Run Tests" type="GradleRunConfiguration" factoryName="Gradle">
+        <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea.log"/>
+        <ExternalSystemSettings>
+            <option name="executionName"/>
+            <option name="externalProjectPath" value="$PROJECT_DIR$"/>
+            <option name="externalSystemIdString" value="GRADLE"/>
+            <option name="scriptParameters" value="--stacktrace"/>
+            <option name="taskDescriptions">
+                <list/>
+            </option>
+            <option name="taskNames">
+                <list>
+                    <option value="check"/>
+                </list>
+            </option>
+            <option name="vmOptions" value=""/>
+        </ExternalSystemSettings>
+        <GradleScriptDebugEnabled>true</GradleScriptDebugEnabled>
+        <method v="2"/>
+    </configuration>
 </component>

--- a/.run/Run Plugin Verification.run.xml
+++ b/.run/Run Plugin Verification.run.xml
@@ -1,5 +1,6 @@
 <component name="ProjectRunConfigurationManager">
     <configuration default="false" name="Run Verifications" type="GradleRunConfiguration" factoryName="Gradle">
+        <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea.log"/>
         <ExternalSystemSettings>
             <option name="executionName"/>
             <option name="externalProjectPath" value="$PROJECT_DIR$"/>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,12 @@
 # nx-webstorm Changelog
 
 ## [Unreleased]
+
 ### Added
 
 ### Changed
+
+- updated the plugin to the latest plugin template of 0.8.0
 
 ### Deprecated
 
@@ -14,6 +17,7 @@
 ### Fixed
 
 ### Security
+
 ## [0.7.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -84,6 +84,6 @@ use Nx, since the schematics are built-in the `@schematics/angular` collection.
   about releases containing new features and fixes.
 
 ---
-Plugin based on the [IntelliJ Platform Plugin Template][template] v0.7.1.
+Plugin based on the [IntelliJ Platform Plugin Template][template] v0.8.0.
 
 [template]: https://github.com/JetBrains/intellij-platform-plugin-template

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,13 +7,13 @@ plugins {
   // Java support
   id("java")
   // Kotlin support
-  id("org.jetbrains.kotlin.jvm") version "1.4.20"
+  id("org.jetbrains.kotlin.jvm") version "1.4.21"
   // gradle-intellij-plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
   id("org.jetbrains.intellij") version "0.6.5"
   // gradle-changelog-plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
   id("org.jetbrains.changelog") version "0.6.2"
   // detekt linter - read more: https://detekt.github.io/detekt/gradle.html
-  id("io.gitlab.arturbosch.detekt") version "1.14.2"
+  id("io.gitlab.arturbosch.detekt") version "1.15.0"
   // ktlint linter - read more: https://github.com/JLLeitschuh/ktlint-gradle
   id("org.jlleitschuh.gradle.ktlint") version "9.4.1"
 }
@@ -42,7 +42,7 @@ repositories {
   jcenter()
 }
 dependencies {
-  detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.14.2")
+  detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.15.0")
 }
 
 // Configure gradle-intellij-plugin plugin.
@@ -79,15 +79,13 @@ tasks {
     sourceCompatibility = "1.8"
     targetCompatibility = "1.8"
   }
-  listOf("compileKotlin", "compileTestKotlin").forEach {
-    getByName<KotlinCompile>(it) {
-      kotlinOptions.jvmTarget = "1.8"
-    }
+  withType<KotlinCompile> {
+    kotlinOptions.jvmTarget = "1.8"
   }
 
   runIde {
     setIdeDirectory(
-      "/Users/edwardtkachev/Library/Application Support/JetBrains/Toolbox/apps/WebStorm/ch-0/203.5981.135/WebStorm.app/Contents"
+      "/Users/edwardtkachev/Library/Application Support/JetBrains/Toolbox/apps/WebStorm/ch-0/203.6682.155/WebStorm.app/Contents"
     )
   }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,12 +2,12 @@
 # -> https://www.jetbrains.org/intellij/sdk/docs/reference_guide/intellij_artifacts.html
 pluginGroup=com.github.etkachev.nxwebstorm
 pluginName_=nx-webstorm
-pluginVersion=0.7.0
+pluginVersion=0.7.1
 pluginSinceBuild=202
 pluginUntilBuild=203.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions=2020.1.4, 2020.2.3, 2020.3
+pluginVerifierIdeVersions=2020.1.4, 2020.2.3, 2020.3.1
 platformType=IU
 platformVersion=2020.2
 platformDownloadSources=true

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/MyBundle.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/MyBundle.kt
@@ -11,11 +11,11 @@ object MyBundle : AbstractBundle(BUNDLE) {
 
   @Suppress("SpreadOperator")
   @JvmStatic
-  fun message(@PropertyKey(resourceBundle = BUNDLE) key: String, vararg params: Any) = getMessage(key, *params)
+  fun message(@PropertyKey(resourceBundle = BUNDLE) key: String, vararg params: Any) =
+    getMessage(key, *params)
 
   @Suppress("SpreadOperator")
   @JvmStatic
-  fun messagePointer(@PropertyKey(resourceBundle = BUNDLE) key: String, vararg params: Any) = run {
-    message(key, *params)
-  }
+  fun messagePointer(@PropertyKey(resourceBundle = BUNDLE) key: String, vararg params: Any) =
+    getLazyMessage(key, *params)
 }


### PR DESCRIPTION
## Current Behavior

<!-- The behavior we have today before this PR is merged -->
- plugin is off of plugin template [0.7.1](https://github.com/JetBrains/intellij-platform-plugin-template/releases/tag/v0.7.1)

## Expected Behavior

<!-- The behavior we will have after the PR is merged -->
- plugin should be off of plugin template [0.8.0](https://github.com/JetBrains/intellij-platform-plugin-template/releases/tag/v0.8.0)

## Motivation

<!-- Why is this behavior expected? -->
- use latest plugin template

## Related Issue

<!-- Please link an issue from github -->
<!-- that may provide more information regarding this PR -->

## Additional Notes

<!-- ... -->
