### PR TITLE
feat: refresh button icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changed
 
+- Refresh button for schematic list tool window is now an icon.
 - updated the plugin to the latest plugin template of 0.8.0
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Refresh button for schematic list tool window is now an icon.
 - updated the plugin to the latest plugin template of 0.8.0
+- gradle.properties `platformVersion` updated to 2020.3
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ pluginUntilBuild=203.*
 # See https://jb.gg/intellij-platform-builds-list for available build versions
 pluginVerifierIdeVersions=2020.1.4, 2020.2.3, 2020.3.1
 platformType=IU
-platformVersion=2020.2
+platformVersion=2020.3
 platformDownloadSources=true
 # Plugin Dependencies -> https://www.jetbrains.org/intellij/sdk/docs/basics/plugin_structure/plugin_dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/actionlisteners/ReFetchSchematicsListener.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/actionlisteners/ReFetchSchematicsListener.kt
@@ -4,7 +4,6 @@ import com.github.etkachev.nxwebstorm.ui.SchematicsListToolTab
 import com.github.etkachev.nxwebstorm.utils.FindAllSchematics
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.ui.content.ContentFactory
-import java.awt.event.ActionEvent
 
 class ReFetchSchematicsListener(
   private val toolWindow: ToolWindow,

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/actionlisteners/ReFetchSchematicsListener.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/actionlisteners/ReFetchSchematicsListener.kt
@@ -17,7 +17,7 @@ class ReFetchSchematicsListener(
   /**
    * gets the action listener re-fetching schematics.
    */
-  fun getActionListener(removeOldListener: () -> Unit): (ActionEvent) -> Unit {
+  fun getActionListener(removeOldListener: () -> Unit): () -> Unit {
     return { fetchSchematics(removeOldListener) }
   }
 

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/SchematicsListToolTab.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/SchematicsListToolTab.kt
@@ -5,7 +5,12 @@ import com.github.etkachev.nxwebstorm.actionlisteners.SchematicSelectionTabListe
 import com.github.etkachev.nxwebstorm.models.SchematicInfo
 import com.github.etkachev.nxwebstorm.services.MyProjectService
 import com.github.etkachev.nxwebstorm.services.NodeDebugConfigState
+import com.github.etkachev.nxwebstorm.ui.buttons.SchematicActionButtons
 import com.github.etkachev.nxwebstorm.utils.FindAllSchematics
+import com.intellij.openapi.actionSystem.ActionPlaces
+import com.intellij.openapi.actionSystem.ActionToolbar
+import com.intellij.openapi.actionSystem.DefaultActionGroup
+import com.intellij.openapi.actionSystem.impl.ActionButton
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.ui.components.JBScrollPane
@@ -46,6 +51,15 @@ class SchematicsListToolTab(
     table.selectionModel.removeListSelectionListener(listener)
   }
 
+  private fun getRefreshButton(removeListener: () -> Unit): ActionButton {
+    val actionGroup = DefaultActionGroup()
+    actionGroup.add(SchematicActionButtons.refresh(this.reFetchListener.getActionListener(removeListener)))
+    val myActions = actionGroup.getChildren(null)
+    val firstBtn = myActions[0]
+    val presentation = firstBtn.templatePresentation
+    return ActionButton(firstBtn, presentation, ActionPlaces.UNKNOWN, ActionToolbar.DEFAULT_MINIMUM_BUTTON_SIZE)
+  }
+
   fun createCenterPanel(schematics: Map<String, SchematicInfo>): JComponent? {
     val generateTable = GenerateTable(schematics)
     val tableData = generateTable.getTable()
@@ -69,15 +83,15 @@ class SchematicsListToolTab(
       nxService.setNxDebugConfigSetupDone()
     }
 
+    val refreshButton = this.getRefreshButton(removeListener)
+    refreshButton.isEnabled = true
+
     val border = BorderFactory.createEmptyBorder(10, 10, 10, 10)
     return panel {
       row {
         searchField()
         right {
-          button(
-            "Refresh",
-            reFetchListener.getActionListener(removeListener)
-          )
+          refreshButton()
         }
       }
       row {

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/buttons/SchematicActionButtons.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/buttons/SchematicActionButtons.kt
@@ -8,6 +8,7 @@ object SchematicActionButtons {
   fun run(action: () -> Unit) = RunSchematicActionButton(action)
   fun debug(action: () -> Unit) = DebugSchematicActionButton(action)
   fun dryRun(action: () -> Unit) = DryRunSchematicActionButton(action)
+  fun refresh(action: () -> Unit) = RefreshSchematicsListActionButton(action)
 }
 
 class RunSchematicActionButton(private val action: () -> Unit) : AnAction(
@@ -34,6 +35,16 @@ class DryRunSchematicActionButton(private val action: () -> Unit) : AnAction(
   "Dry Run",
   "Dry Run Schematic",
   AllIcons.General.RunWithCoverage
+) {
+  override fun actionPerformed(e: AnActionEvent) {
+    this.action.invoke()
+  }
+}
+
+class RefreshSchematicsListActionButton(private val action: () -> Unit) : AnAction(
+  "Refresh",
+  "Re-fetch all possible schematics",
+  AllIcons.Actions.Refresh
 ) {
   override fun actionPerformed(e: AnActionEvent) {
     this.action.invoke()


### PR DESCRIPTION
## Current Behavior

<!-- The behavior we have today before this PR is merged -->
- Refresh button for schematics list was text button
- platformVersion on gradle.properties was set to `2020.2`
  - this caused kotlin errors in IDE with latest update to Intellij

## Expected Behavior

<!-- The behavior we will have after the PR is merged -->
- Refresh button for schematics list should be icon button
- platformVersion on gradle.properties should be set to `2020.3`

## Motivation

<!-- Why is this behavior expected? -->
- simpler ui for refresh button
- fix IDE errors related to kotlin

## Related Issue

<!-- Please link an issue from github -->
<!-- that may provide more information regarding this PR -->

## Additional Notes

<!-- ... -->
