### PR TITLE
fix: bug in settings for custom schematics directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Fixed
 
+- fixed issue where settings plugin for custom schematics directory was not able to configure or change.
+
 ### Security
 
 ## [0.7.1]

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginProjectSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginProjectSettingsConfigurable.kt
@@ -47,8 +47,18 @@ class PluginProjectSettingsConfigurable(val project: Project) : Configurable {
     val settings: PluginProjectSettingsState = PluginProjectSettingsState.getInstance(this.project)
     val projService = MyProjectService.getInstance(this.project)
     mySettingsComponent!!.scanExplicitLibsStatus = settings.scanExplicitLibs
-    mySettingsComponent!!.customSchematicsDirText = if (settings.customSchematicsLocation.isNotBlank())
-      settings.customSchematicsLocation else projService.defaultCustomSchematicsLocation
+    mySettingsComponent!!.customSchematicsDirText = this.getCustomSchematicsLocationFromState(settings, projService)
+  }
+
+  private fun getCustomSchematicsLocationFromState(
+    settings: PluginProjectSettingsState,
+    projService: MyProjectService
+  ): String {
+    return if (settings.customSchematicsLocation.isNotBlank()) {
+      settings.customSchematicsLocation
+    } else {
+      projService.defaultCustomSchematicsLocation
+    }
   }
 
   override fun disposeUIResources() {

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginProjectSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginProjectSettingsConfigurable.kt
@@ -33,7 +33,7 @@ class PluginProjectSettingsConfigurable(val project: Project) : Configurable {
     val settingCustomSchemDir = settings.customSchematicsLocation
     val componentSchematicText = mySettingsComponent!!.customSchematicsDirText
     modified = modified or
-      (componentSchematicText != settingCustomSchemDir && settingCustomSchemDir != null)
+      (componentSchematicText != settingCustomSchemDir)
     return modified
   }
 
@@ -47,8 +47,8 @@ class PluginProjectSettingsConfigurable(val project: Project) : Configurable {
     val settings: PluginProjectSettingsState = PluginProjectSettingsState.getInstance(this.project)
     val projService = MyProjectService.getInstance(this.project)
     mySettingsComponent!!.scanExplicitLibsStatus = settings.scanExplicitLibs
-    mySettingsComponent!!.customSchematicsDirText =
-      settings.customSchematicsLocation ?: projService.defaultCustomSchematicsLocation
+    mySettingsComponent!!.customSchematicsDirText = if (settings.customSchematicsLocation.isNotBlank())
+      settings.customSchematicsLocation else projService.defaultCustomSchematicsLocation
   }
 
   override fun disposeUIResources() {

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginProjectSettingsState.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginProjectSettingsState.kt
@@ -19,7 +19,7 @@ import com.intellij.util.xmlb.XmlSerializerUtil
 class PluginProjectSettingsState : PersistentStateComponent<PluginProjectSettingsState?> {
   var externalLibs = PluginSettingsState.instance.externalLibs.split(",").toTypedArray()
   var scanExplicitLibs = PluginSettingsState.instance.scanExplicitLibs
-  var customSchematicsLocation: String? = null
+  var customSchematicsLocation: String = ""
 
   override fun getState(): PluginProjectSettingsState {
     return this

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/utils/FindSchematics.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/utils/FindSchematics.kt
@@ -24,7 +24,13 @@ class FindAllSchematics(private val project: Project) {
   private val projectSettings = PluginProjectSettingsState.getInstance(project)
   private val defaultToolsSchematicDir = MyProjectService.getInstance(this.project).defaultCustomSchematicsLocation
   private val configToolsSchematicDir: String
-    get() = if (projectSettings.customSchematicsLocation.isNotBlank()) projectSettings.customSchematicsLocation else this.defaultToolsSchematicDir
+    get() {
+      return if (projectSettings.customSchematicsLocation.isNotBlank()) {
+        projectSettings.customSchematicsLocation
+      } else {
+        this.defaultToolsSchematicDir
+      }
+    }
   private val jsonFileReader = ReadFile.getInstance(project)
   private val packageJsonHelper = PackageJsonHelper(project)
   private val schematicPropName = "schematics"

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/utils/FindSchematics.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/utils/FindSchematics.kt
@@ -24,7 +24,7 @@ class FindAllSchematics(private val project: Project) {
   private val projectSettings = PluginProjectSettingsState.getInstance(project)
   private val defaultToolsSchematicDir = MyProjectService.getInstance(this.project).defaultCustomSchematicsLocation
   private val configToolsSchematicDir: String
-    get() = projectSettings.customSchematicsLocation ?: this.defaultToolsSchematicDir
+    get() = if (projectSettings.customSchematicsLocation.isNotBlank()) projectSettings.customSchematicsLocation else this.defaultToolsSchematicDir
   private val jsonFileReader = ReadFile.getInstance(project)
   private val packageJsonHelper = PackageJsonHelper(project)
   private val schematicPropName = "schematics"


### PR DESCRIPTION
## Current Behavior

<!-- The behavior we have today before this PR is merged -->
- when going to configure plugin settings:
  - custom schematics folder was not able to change or be configured

## Expected Behavior

<!-- The behavior we will have after the PR is merged -->
- when configuring plugin settings:
  - custom schematics folder is now fully configurable and has a default fallback when empty.

## Motivation

<!-- Why is this behavior expected? -->
- bug fixes

## Related Issue

<!-- Please link an issue from github -->
<!-- that may provide more information regarding this PR -->

## Additional Notes

<!-- ... -->
