### PR TITLE
fix: bash commands sometimes execute within commands of schematics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Fixed
 
 - fixed issue where settings plugin for custom schematics directory was not able to configure or change.
+- fixed issue where commands run would sometimes be replaced when running bash shortcuts such as those starting with "!"
 
 ### Security
 

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/actionlisteners/SchematicSelectionTabListener.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/actionlisteners/SchematicSelectionTabListener.kt
@@ -10,7 +10,7 @@ import com.github.etkachev.nxwebstorm.services.NodeDebugConfigState
 import com.github.etkachev.nxwebstorm.ui.RunSchematicPanel
 import com.github.etkachev.nxwebstorm.ui.RunTerminalWindow
 import com.github.etkachev.nxwebstorm.utils.foldListOfMaps
-import com.github.etkachev.nxwebstorm.utils.getSchematicCommandFromValues
+import com.github.etkachev.nxwebstorm.utils.getSchematicCommandArgs
 import com.github.etkachev.nxwebstorm.utils.getSchematicIdFromTableSelect
 import com.github.etkachev.nxwebstorm.utils.splitSchematicId
 import com.google.gson.JsonArray
@@ -92,11 +92,11 @@ class SchematicSelectionTabListener(
     }
     val projectType = this.nxService.nxProjectType
     val schematicCommandData = SchematicCommandData(projectType, type, collectionPath)
-    val command = getSchematicCommandFromValues(collection, id, values, schematicCommandData, dryRun)
+    val commands = getSchematicCommandArgs(collection, id, values, schematicCommandData, dryRun)
     if (dryRun) {
-      dryRunTerminal.runAndShow(command)
+      dryRunTerminal.runAndShow(commands.joinToString(" "))
     } else {
-      runTerminal.runAndShow(command)
+      runTerminal.runAndShow(commands.joinToString(" "))
     }
   }
 

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/utils/GenerateTerminalCommand.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/utils/GenerateTerminalCommand.kt
@@ -28,13 +28,42 @@ fun getSchematicCommandFromValues(
   return "$newPrefix $flags --no-interactive$dryRunString"
 }
 
+fun getSchematicCommandArgs(
+  collection: String,
+  id: String,
+  values: MutableMap<String, String>,
+  commandData: SchematicCommandData,
+  dryRun: Boolean = true
+): List<String> {
+  val result = mutableListOf<String>()
+  val (nxPath, nxExec) = CliCommands.NX.data
+  val (ngPath, ngExec) = CliCommands.NG.data
+  val (nxProjectType, schematicType, collectionPath) = commandData
+  val nx = "$nxPath/$nxExec"
+  val ng = "$ngPath/$ngExec"
+  val cli = if (nxProjectType == NxProjectType.Nx) nx else ng
+  val initialPrefix = when (schematicType) {
+    SchematicTypeEnum.PROVIDED -> listOf("node", cli, "generate", "$collection:$id")
+    SchematicTypeEnum.CUSTOM_NX -> listOf("node", cli, "workspace-schematic", id)
+    SchematicTypeEnum.CUSTOM_ANGULAR -> listOf("schematics", ".$collectionPath:$id")
+  }
+  val flags = getCommandArguments(values)
+  result.addAll(initialPrefix)
+  result.addAll(flags)
+  result.add("--no-interactive")
+  if (dryRun) {
+    result.add("--dry-run")
+  }
+  return result.toList()
+}
+
 fun getCommandArguments(values: Map<String, String>): List<String> {
   return values.keys.mapNotNull { key ->
     val value = values[key]
     val finalText = if (value == "true" || value == "false") {
       if (value == "true") "--$key" else null
     } else if (value != null && value.isNotBlank()) {
-      val cleanedValue = if (value.contains(" ")) "'$value'" else value
+      val cleanedValue = if (value.contains(" ") || value.contains("!")) "'$value'" else value
       "--$key=$cleanedValue"
     } else {
       null


### PR DESCRIPTION
## Current Behavior

<!-- The behavior we have today before this PR is merged -->
- if any args from the schematics contain [bash shortcuts](https://kapeli.com/cheat_sheets/Bash_Shortcuts.docset/Contents/Resources/Documents/index) that start with `!` then it sometimes replaces that string with some recent ran commands within bash.

## Expected Behavior

<!-- The behavior we will have after the PR is merged -->
- any args inputted for schematics that contain character `!` should be wrapped in single quote strings to avoid bash shortcuts executing.
- also new util for outputting commands in list of strings rather than single string.

## Motivation

<!-- Why is this behavior expected? -->
- small edge case bug fix.

## Related Issue

<!-- Please link an issue from github -->
<!-- that may provide more information regarding this PR -->

## Additional Notes

<!-- ... -->
