### PR TITLE
feat: added more nrwl default packages for settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,12 @@
 # nx-webstorm Changelog
 
 ## [Unreleased]
+
 ### Added
 
 ### Changed
+
+- Under plugin settings, the default list of external schematics to scan, now includes more default nrwl packages
 
 ### Deprecated
 
@@ -14,13 +17,14 @@
 ### Fixed
 
 ### Security
-## [unspecified]
+
+## [0.7.2]
 
 ### Added
 
 ### Changed
 
-- updated the plugin to the latest plugin template of 0.8.0
+- updated the plugin to the latest plugin template of 0.8.1
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # -> https://www.jetbrains.org/intellij/sdk/docs/reference_guide/intellij_artifacts.html
 pluginGroup=com.github.etkachev.nxwebstorm
 pluginName_=nx-webstorm
-pluginVersion=0.7.2
+pluginVersion=0.8.0
 pluginSinceBuild=202
 pluginUntilBuild=203.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginSettingsState.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginSettingsState.kt
@@ -25,10 +25,16 @@ class PluginSettingsState : PersistentStateComponent<PluginSettingsState?> {
     "@nrwl/workspace",
     "@schematics/angular",
     "@nestjs/schematics",
-    "@ngrx/schematics"
+    "@ngrx/schematics",
+    "@nrwl/react",
+    "@nrwl/web",
+    "@nrwl/gatsby",
+    "@nrwl/bazel",
+    "@nrwl/express",
+    "@nrwl/next",
+    "@nrwl/nx-plugin"
   ).joinToString(", ")
   var scanExplicitLibs = true
-  var customSchematicsLocation = "/tools/schematics"
   var schematicActionButtonsPlacement = SchematicActionButtonPlacement.TOP.data
 
   override fun getState(): PluginSettingsState? {


### PR DESCRIPTION
## Current Behavior

<!-- The behavior we have today before this PR is merged -->
- under settings for plugin, default list of schematic packages to scan were missing a few new ones.

## Expected Behavior

<!-- The behavior we will have after the PR is merged -->
- under settings for plugin, default list of schematic packages to scan now include: 
  - `@nrwl/react`
  - `@nrwl/web`
  - `@nrwl/gatsby`
  - `@nrwl/bazel`
  - `@nrwl/express`
  - `@nrwl/next`
  - `@nrwl/nx-plugin`

## Motivation

<!-- Why is this behavior expected? -->
More default setup for external schematics to scan.

## Related Issue

<!-- Please link an issue from github -->
<!-- that may provide more information regarding this PR -->
#43 

## Additional Notes

<!-- ... -->
