### PR TITLE
feat(settings): configure root nx directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- New Plugin Setting for configuring root directory of nx project. By default, it will be `/`
+
 ### Changed
 
 - Under plugin settings, the default list of external schematics to scan, now includes more default nrwl packages
@@ -15,6 +17,9 @@
 ### Removed
 
 ### Fixed
+
+- Fixed situations where Debug schematic wouldn't work if workspace did not have any other run configs setup in
+  Jetbrains IDE.
 
 ### Security
 

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/actionlisteners/DryRunAction.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/actionlisteners/DryRunAction.kt
@@ -4,7 +4,7 @@ import com.github.etkachev.nxwebstorm.models.DryRunButtonData
 import com.github.etkachev.nxwebstorm.models.SchematicCommandData
 import com.github.etkachev.nxwebstorm.services.MyProjectService
 import com.github.etkachev.nxwebstorm.ui.RunTerminalWindow
-import com.github.etkachev.nxwebstorm.utils.getSchematicCommandFromValues
+import com.github.etkachev.nxwebstorm.utils.getSchematicCommandArgs
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogWrapper
 import java.awt.event.ActionEvent
@@ -22,8 +22,8 @@ class DryRunAction(
     val values = formValues.formVal
     val projectType = nxService.nxProjectType
     val schematicCommandData = SchematicCommandData(projectType, type, collectionPath)
-    val command = getSchematicCommandFromValues(collection, id, values, schematicCommandData, true)
+    val commands = getSchematicCommandArgs(collection, id, values, schematicCommandData, true)
     dialog.close(DialogWrapper.CANCEL_EXIT_CODE)
-    terminal.runAndShow(command)
+    terminal.runAndShow(commands.joinToString(" "))
   }
 }

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/actions/Generate.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/actions/Generate.kt
@@ -7,7 +7,7 @@ import com.github.etkachev.nxwebstorm.ui.RunSchematicDialog
 import com.github.etkachev.nxwebstorm.ui.RunTerminalWindow
 import com.github.etkachev.nxwebstorm.ui.SchematicsListDialog
 import com.github.etkachev.nxwebstorm.utils.FindAllSchematics
-import com.github.etkachev.nxwebstorm.utils.getSchematicCommandFromValues
+import com.github.etkachev.nxwebstorm.utils.getSchematicCommandArgs
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 
@@ -37,10 +37,9 @@ class Generate : AnAction() {
         val values = formDialog.formMap.formVal
         val projectType = nxService.nxProjectType
         val schematicCommandData = SchematicCommandData(projectType, enumType, collectionPath)
-        val command =
-          getSchematicCommandFromValues(collection, id, values, schematicCommandData, false)
+        val commands = getSchematicCommandArgs(collection, id, values, schematicCommandData, false)
         val terminal = RunTerminalWindow(proj, "Run")
-        terminal.runAndShow(command)
+        terminal.runAndShow(commands.joinToString(" "))
       }
     }
   }

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/services/NodeDebugConfigState.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/services/NodeDebugConfigState.kt
@@ -137,17 +137,11 @@ class NodeDebugConfigState(project: Project) {
   ): Document {
     val docFile = readWorkspaceFile()
     for (content in docFile.rootElement.children) {
-      if (this.isComponentRunManager(content)) {
+      if (isComponentRunManager(content, this.componentElementName, runManagerName)) {
         this.setNxConfigAttributes(content, command, name, args, type)
       }
     }
     return docFile
-  }
-
-  private fun isComponentRunManager(element: Element): Boolean {
-    val isComponent = element.name == this.componentElementName
-    val isRunManager = element.attributes.find { ca -> ca.name == "name" && ca.value == runManagerName } != null
-    return isComponent && isRunManager
   }
 
   /**
@@ -230,4 +224,10 @@ internal fun elementAttributesAreNxDebugConfig(
  */
 internal fun joinArgsWithCommand(command: String, name: String, args: Map<String, String>): String {
   return "$command $name " + getCommandArguments(args).joinToString(" ")
+}
+
+internal fun isComponentRunManager(element: Element, componentElementName: String, runManagerName: String): Boolean {
+  val isComponent = element.name == componentElementName
+  val isRunManager = element.attributes.find { ca -> ca.name == "name" && ca.value == runManagerName } != null
+  return isComponent && isRunManager
 }

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/services/NodeDebugConfigState.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/services/NodeDebugConfigState.kt
@@ -22,6 +22,7 @@ class NodeDebugConfigState(project: Project) {
   private val readFile: ReadFile = ReadFile.getInstance(this.proj)
   private val runManagerName: String = "RunManager"
   private val configElementName: String = "configuration"
+  private val componentElementName = "component"
   private val argsAttribute: String = "application-parameters"
   private val pathToJsFileAttribute: String = "path-to-js-file"
   private val workDirAttribute: String = "working-dir"
@@ -49,8 +50,10 @@ class NodeDebugConfigState(project: Project) {
     ApplicationManager.getApplication().invokeLater {
       val doc = readWorkspaceFile()
       var hasExistingConfig = false
+      var hasExistingRunManager = false
       for (content in doc.rootElement.children) {
-        if (content.name == "component" && elementAttributesIsRunManager(content.attributes, runManagerName)) {
+        if (content.name == componentElementName && elementAttributesIsRunManager(content.attributes, runManagerName)) {
+          hasExistingRunManager = true
           for (runManagerChild in content.children) {
             if (elementAttributesAreNxDebugConfig(runManagerChild, configElementName, nxDebugConfigName)) {
               hasExistingConfig = true
@@ -61,10 +64,14 @@ class NodeDebugConfigState(project: Project) {
           }
         }
       }
+
+      if (!hasExistingRunManager) {
+        doc.rootElement.addContent(this.generateEmptyRunManager(cli))
+      }
       /**
        * only save if we added new config
        */
-      if (!hasExistingConfig) {
+      if (!hasExistingConfig || !hasExistingRunManager) {
         this.saveWorkspaceFile(doc)
       }
     }
@@ -112,8 +119,9 @@ class NodeDebugConfigState(project: Project) {
     } else {
       val (path, exec) = cli.data
       val projDir = if (initialSetup) "\$PROJECT_DIR\$" else this.proj.basePath
+      val baseDir = if (nxService.configuredRootPath == "/") "/" else "/${nxService.configuredRootPath}/"
       runManagerChild.setAttribute(pathToJsFileAttribute, exec)
-      runManagerChild.setAttribute(workDirAttribute, "$projDir/$path")
+      runManagerChild.setAttribute(workDirAttribute, "$projDir$baseDir$path")
     }
   }
 
@@ -137,7 +145,7 @@ class NodeDebugConfigState(project: Project) {
   }
 
   private fun isComponentRunManager(element: Element): Boolean {
-    val isComponent = element.name == "component"
+    val isComponent = element.name == this.componentElementName
     val isRunManager = element.attributes.find { ca -> ca.name == "name" && ca.value == runManagerName } != null
     return isComponent && isRunManager
   }
@@ -148,17 +156,26 @@ class NodeDebugConfigState(project: Project) {
   private fun generateEmptyNxDebugConfig(cli: CliCommands): Element {
     val newConfig = Element(configElementName)
     val cliPath = cli.data.path
+    val rootDir = if (nxService.configuredRootPath == "/") "/" else "/${nxService.configuredRootPath}/"
     val attributes = listOf(
       Attribute("name", nxDebugConfigName),
       Attribute("type", nodeJsConfigTypeName),
       Attribute(argsAttribute, ""),
       Attribute(pathToJsFileAttribute, cli.data.exec),
-      Attribute(workDirAttribute, "\$PROJECT_DIR\$/$cliPath")
+      Attribute(workDirAttribute, "\$PROJECT_DIR\$$rootDir$cliPath")
     )
     newConfig.attributes = attributes
     val methodEl = Element("method")
     methodEl.setAttribute("v", "2")
     newConfig.addContent(methodEl)
+    return newConfig
+  }
+
+  private fun generateEmptyRunManager(cli: CliCommands): Element {
+    val newConfig = Element(componentElementName)
+    val attributes = listOf(Attribute("name", runManagerName))
+    newConfig.attributes = attributes
+    newConfig.addContent(generateEmptyNxDebugConfig(cli))
     return newConfig
   }
 

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/RunTerminalWindow.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/RunTerminalWindow.kt
@@ -1,5 +1,6 @@
 package com.github.etkachev.nxwebstorm.ui
 
+import com.github.etkachev.nxwebstorm.services.MyProjectService
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowManager
@@ -12,10 +13,13 @@ class RunTerminalWindow(private val proj: Project, private val tabName: String? 
 
   var terminalView: TerminalView = TerminalView.getInstance(proj)
   var shell: ShellTerminalWidget? = null
+  private val nxService = MyProjectService.getInstance(this.proj)
+  private val workingDir: String?
+    get() = if (nxService.configuredRootPath == "/") null else "${this.proj.basePath}/${nxService.configuredRootPath}"
   var terminalWindow = getWindowManager()
 
   private fun createShell(window: ToolWindow): Content {
-    shell = terminalView.createLocalShellWidget(null, tabName)
+    shell = terminalView.createLocalShellWidget(workingDir, tabName)
     val tabContent = window.contentManager.findContent(tabName)
     return tabContent!!
   }

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginProjectSettingsComponent.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginProjectSettingsComponent.kt
@@ -14,6 +14,7 @@ class PluginProjectSettingsComponent {
   val panel: JPanel
   private val myScanExplicitLibsStatus: JBCheckBox
   private val myCustomSchematicsDirectory: JBTextField = JBTextField()
+  private val myRootNxDirectory: JBTextField = JBTextField()
 
   val preferredFocusedComponent: JComponent
     get() = myScanExplicitLibsStatus
@@ -26,6 +27,12 @@ class PluginProjectSettingsComponent {
     get() = myCustomSchematicsDirectory.text
     set(dir) {
       myCustomSchematicsDirectory.text = dir
+    }
+
+  var rootNxDirectoryText: String
+    get() = myRootNxDirectory.text
+    set(dir) {
+      myRootNxDirectory.text = dir
     }
 
   init {
@@ -51,6 +58,14 @@ class PluginProjectSettingsComponent {
         }
         row {
           myCustomSchematicsDirectory()
+        }
+      }
+      titledRow("Root Nx Directory") {
+        row {
+          label("Enter directory where your nx project resides")
+        }
+        row {
+          myRootNxDirectory()
         }
       }
     }.withBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10))

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginProjectSettingsComponent.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginProjectSettingsComponent.kt
@@ -62,7 +62,7 @@ class PluginProjectSettingsComponent {
       }
       titledRow("Root Nx Directory") {
         row {
-          label("Enter directory where your nx project resides")
+          label("Enter directory where your nx project resides. (Most of the time it will be '/')")
         }
         row {
           myRootNxDirectory()

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginProjectSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginProjectSettingsConfigurable.kt
@@ -32,8 +32,11 @@ class PluginProjectSettingsConfigurable(val project: Project) : Configurable {
     var modified: Boolean = mySettingsComponent!!.scanExplicitLibsStatus != settings.scanExplicitLibs
     val settingCustomSchemDir = settings.customSchematicsLocation
     val componentSchematicText = mySettingsComponent!!.customSchematicsDirText
+    val settingsRootDir = settings.rootDirectory
+    val componentRootDirText = mySettingsComponent!!.rootNxDirectoryText
     modified = modified or
-      (componentSchematicText != settingCustomSchemDir)
+      (componentSchematicText != settingCustomSchemDir) or
+      (componentRootDirText != settingsRootDir)
     return modified
   }
 
@@ -41,6 +44,7 @@ class PluginProjectSettingsConfigurable(val project: Project) : Configurable {
     val settings: PluginProjectSettingsState = PluginProjectSettingsState.getInstance(this.project)
     settings.scanExplicitLibs = mySettingsComponent!!.scanExplicitLibsStatus
     settings.customSchematicsLocation = mySettingsComponent!!.customSchematicsDirText
+    settings.rootDirectory = this.getValidRootNxDirectory(mySettingsComponent!!.rootNxDirectoryText)
   }
 
   override fun reset() {
@@ -48,6 +52,16 @@ class PluginProjectSettingsConfigurable(val project: Project) : Configurable {
     val projService = MyProjectService.getInstance(this.project)
     mySettingsComponent!!.scanExplicitLibsStatus = settings.scanExplicitLibs
     mySettingsComponent!!.customSchematicsDirText = this.getCustomSchematicsLocationFromState(settings, projService)
+    mySettingsComponent!!.rootNxDirectoryText = this.getRootNxDirectoryFromState(settings, projService)
+  }
+
+  private fun getValidRootNxDirectory(input: String): String {
+    val projService = MyProjectService.getInstance(this.project)
+    return if (input.trim().isNotBlank()) {
+      return input.trim()
+    } else {
+      projService.defaultRootDirectory
+    }
   }
 
   private fun getCustomSchematicsLocationFromState(
@@ -58,6 +72,17 @@ class PluginProjectSettingsConfigurable(val project: Project) : Configurable {
       settings.customSchematicsLocation
     } else {
       projService.defaultCustomSchematicsLocation
+    }
+  }
+
+  private fun getRootNxDirectoryFromState(
+    settings: PluginProjectSettingsState,
+    projService: MyProjectService
+  ): String {
+    return if (settings.rootDirectory.trim().isNotBlank()) {
+      settings.rootDirectory
+    } else {
+      projService.defaultRootDirectory
     }
   }
 

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginProjectSettingsState.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/ui/settings/PluginProjectSettingsState.kt
@@ -20,6 +20,7 @@ class PluginProjectSettingsState : PersistentStateComponent<PluginProjectSetting
   var externalLibs = PluginSettingsState.instance.externalLibs.split(",").toTypedArray()
   var scanExplicitLibs = PluginSettingsState.instance.scanExplicitLibs
   var customSchematicsLocation: String = ""
+  var rootDirectory: String = "/"
 
   override fun getState(): PluginProjectSettingsState {
     return this

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/utils/FindSchematics.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/utils/FindSchematics.kt
@@ -22,7 +22,8 @@ data class CollectionInfo(val json: JsonObject, val file: VirtualFile, val relat
  */
 class FindAllSchematics(private val project: Project) {
   private val projectSettings = PluginProjectSettingsState.getInstance(project)
-  private val defaultToolsSchematicDir = MyProjectService.getInstance(this.project).defaultCustomSchematicsLocation
+  private val nxService = MyProjectService.getInstance(project)
+  private val defaultToolsSchematicDir = this.nxService.defaultCustomSchematicsLocation
   private val configToolsSchematicDir: String
     get() {
       return if (projectSettings.customSchematicsLocation.isNotBlank()) {
@@ -34,8 +35,15 @@ class FindAllSchematics(private val project: Project) {
   private val jsonFileReader = ReadFile.getInstance(project)
   private val packageJsonHelper = PackageJsonHelper(project)
   private val schematicPropName = "schematics"
-  private var nodeModulesFolder = "node_modules"
-  private val nxService = MyProjectService.getInstance(project)
+  private val nodeModulesFolder: String
+    get() {
+      val rootDir = this.nxService.configuredRootPath
+      return if (rootDir == "/") {
+        "node_modules"
+      } else {
+        "$rootDir/node_modules"
+      }
+    }
 
   private val cleanedUpConfigToolsSchematicDir: String
     get() = if (configToolsSchematicDir.startsWith("/")) configToolsSchematicDir else "/$configToolsSchematicDir"

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/utils/GenerateTerminalCommand.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/utils/GenerateTerminalCommand.kt
@@ -5,32 +5,6 @@ import com.github.etkachev.nxwebstorm.models.NxProjectType
 import com.github.etkachev.nxwebstorm.models.SchematicCommandData
 import com.github.etkachev.nxwebstorm.models.SchematicTypeEnum
 
-/**
- * TODO remove later
- */
-fun getSchematicCommandFromValues(
-  collection: String,
-  id: String,
-  values: MutableMap<String, String>,
-  commandData: SchematicCommandData,
-  dryRun: Boolean = true
-): String {
-  val dryRunString = if (dryRun) " --dry-run" else ""
-  val (nxPath, nxExec) = CliCommands.NX.data
-  val (ngPath, ngExec) = CliCommands.NG.data
-  val nx = "node $nxPath/$nxExec"
-  val ng = "node $ngPath/$ngExec"
-  val (nxProjectType, schematicType, collectionPath) = commandData
-  val cli = if (nxProjectType == NxProjectType.Nx) nx else ng
-  val newPrefix = when (schematicType) {
-    SchematicTypeEnum.PROVIDED -> "$cli generate $collection:$id"
-    SchematicTypeEnum.CUSTOM_NX -> "$cli workspace-schematic $id"
-    SchematicTypeEnum.CUSTOM_ANGULAR -> "schematics .$collectionPath:$id"
-  }
-  val flags = getCommandArguments(values).joinToString(" ")
-  return "$newPrefix $flags --no-interactive$dryRunString"
-}
-
 fun getSchematicCommandArgs(
   collection: String,
   id: String,

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/utils/GenerateTerminalCommand.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/utils/GenerateTerminalCommand.kt
@@ -5,6 +5,9 @@ import com.github.etkachev.nxwebstorm.models.NxProjectType
 import com.github.etkachev.nxwebstorm.models.SchematicCommandData
 import com.github.etkachev.nxwebstorm.models.SchematicTypeEnum
 
+/**
+ * TODO remove later
+ */
 fun getSchematicCommandFromValues(
   collection: String,
   id: String,


### PR DESCRIPTION
## Current Behavior

<!-- The behavior we have today before this PR is merged -->
- there is assumption that every workspace opened in Jetbrains IDE is the root nx project.
- debugging does not work when running in a workspace that does not have any run configs setup

## Expected Behavior

<!-- The behavior we will have after the PR is merged -->
- add project settings to nx-webstorm plugin so that you can configure where the root directory is for nx project.
  - by default it is `/`
- fix bug so that workspaces that don't have run configs setup, will have `RunManager` setup before adding nx debug config

## Motivation

<!-- Why is this behavior expected? -->
- bug fixes and more configuration with unique workspaces using nx

## Related Issue

<!-- Please link an issue from github -->
<!-- that may provide more information regarding this PR -->
#42 

## Additional Notes

<!-- ... -->
