### PR TITLE
chore: support for upcoming 2021 IDE versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,12 @@
 # nx-webstorm Changelog
 
 ## [Unreleased]
+
 ### Added
 
 ### Changed
+
+- added support for build 211.*
 
 ### Deprecated
 
@@ -14,7 +17,8 @@
 ### Fixed
 
 ### Security
-## [unspecified]
+
+## [0.8.0]
 
 ### Added
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,10 +4,10 @@ pluginGroup=com.github.etkachev.nxwebstorm
 pluginName_=nx-webstorm
 pluginVersion=0.8.0
 pluginSinceBuild=202
-pluginUntilBuild=203.*
+pluginUntilBuild=211.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions=2020.1.4, 2020.2.3, 2020.3.1
+pluginVerifierIdeVersions=2020.1.4, 2020.2.3, 2020.3.1, 2021.1
 platformType=IU
 platformVersion=2020.3
 platformDownloadSources=true


### PR DESCRIPTION
## Current Behavior

<!-- The behavior we have today before this PR is merged -->
- support for `pluginUntilBuild=203.*`

## Expected Behavior

<!-- The behavior we will have after the PR is merged -->
- support for `pluginUntilBuild=211.*`

## Motivation

<!-- Why is this behavior expected? -->
smooth transition when 2021 version comes out.

## Related Issue

<!-- Please link an issue from github -->
<!-- that may provide more information regarding this PR -->

## Additional Notes

<!-- ... -->
