### PR TITLE
fix: fixing possible index issue when searching schematics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Fixed
 
+- Fixing issue [#54](https://github.com/etkachev/nx-webstorm/issues/54) with possible index out of bounds on dir split.
+
 ### Security
 
 ## [0.8.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - Updated Plugin template to v0.8.2
+- Switched gradle-wrapper `distributionUrl` back to `-all` config.
 
 ### Deprecated
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-bin.zip
+#switching back from `https\://services.gradle.org/distributions/gradle-6.8.2-bin.zip`
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 #switching back from `https\://services.gradle.org/distributions/gradle-6.8.2-bin.zip`
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/utils/FindSchematics.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/utils/FindSchematics.kt
@@ -190,6 +190,9 @@ class FindAllSchematics(private val project: Project) {
     val collectionJson = jsonFileReader.readJsonFromFile(schematicCollection) ?: return null
     val projPath = project.basePath ?: return null
     val relativePathSplit = schematicCollection.path.split(projPath)
+    if (relativePathSplit.count() < 2) {
+      return null
+    }
     val relativePath = relativePathSplit[1]
     val schematicsOptions =
       (if (collectionJson.has(schematicPropName)) collectionJson[schematicPropName].asJsonObject else null)


### PR DESCRIPTION
## Current Behavior

<!-- The behavior we have today before this PR is merged -->
- There are sometimes cases where directory split fails as mentioned on #54 .

## Expected Behavior

<!-- The behavior we will have after the PR is merged -->
- Plugin should not crash 

## Motivation

<!-- Why is this behavior expected? -->
- Attempting to fix edge case on indexing issue.

## Related Issue

<!-- Please link an issue from github -->
<!-- that may provide more information regarding this PR -->
#54 

## Additional Notes

<!-- ... -->
