### PR TITLE
upgrade to latest webstorm version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Updated Plugin template to v0.10.1
 - Switched gradle-wrapper `distributionUrl` back to `-all` config.
+- Update `pluginUntilBuild` to upcoming Webstorm version `212.*`
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,12 +6,12 @@ pluginVersion=0.8.2
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild=202
-pluginUntilBuild=211.*
+pluginUntilBuild=212.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
-pluginVerifierIdeVersions=2020.2.4, 2020.3.4, 2021.1.1
+pluginVerifierIdeVersions=2020.2.4, 2020.3.4, 2021.1.2, 2021.2
 platformType=IU
-platformVersion=2020.3
+platformVersion=2021.1
 platformDownloadSources=true
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ pluginSinceBuild=202
 pluginUntilBuild=212.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
-pluginVerifierIdeVersions=2020.2.4, 2020.3.4, 2021.1.2, 2021.2
+pluginVerifierIdeVersions=2020.2.4, 2020.3.4, 2021.1.2
 platformType=IU
 platformVersion=2021.1
 platformDownloadSources=true


### PR DESCRIPTION
## Current Behavior

<!-- The behavior we have today before this PR is merged -->
- current `pluginUntilBuild` is set to `211.*`

## Expected Behavior

<!-- The behavior we will have after the PR is merged -->
- update `pluginUntilBuild` to latest `212.*`

## Motivation

<!-- Why is this behavior expected? -->
prepare for upcoming webstorm version update

## Related Issue

<!-- Please link an issue from github -->
<!-- that may provide more information regarding this PR -->

## Additional Notes

<!-- ... -->
