### PR TITLE
feat: support for id prop for new schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 # nx-webstorm Changelog
 
 ## [Unreleased]
+
+### Added
+
+- when searching custom schematics within nx workspaces, also search schema.json files for `$id` property, if `id` is
+  not found. Ticket [#71](https://github.com/etkachev/nx-webstorm/issues/71)
+
 ## [0.8.2]
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 pluginGroup=com.github.etkachev.nxwebstorm
 pluginName=nx-webstorm
-pluginVersion=0.8.2
+pluginVersion=0.9
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild=202

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/models/FullSchematicInfo.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/models/FullSchematicInfo.kt
@@ -1,5 +1,7 @@
 package com.github.etkachev.nxwebstorm.models
 
+import com.google.gson.JsonObject
+
 data class FullSchematicInfo(
   val type: SchematicTypeData,
   val id: String,
@@ -19,6 +21,24 @@ fun mapSchematicTypeStringToEnum(type: String): SchematicTypeEnum {
     SchematicTypeEnum.CUSTOM_ANGULAR.data -> SchematicTypeEnum.CUSTOM_ANGULAR
     else -> SchematicTypeEnum.CUSTOM_NX
   }
+}
+
+fun getIdFromJsonSchema(json: JsonObject): String? {
+  val idProp = if (json.has(SchemaIdProp.STANDARD.prop)) {
+    SchemaIdProp.STANDARD
+  } else if (json.has(SchemaIdProp.NEW.prop)) {
+    SchemaIdProp.NEW
+  } else {
+    SchemaIdProp.NONE
+  }
+
+  return if (idProp == SchemaIdProp.NONE) null else json.get(idProp.prop).asString
+}
+
+enum class SchemaIdProp(val prop: String) {
+  STANDARD("id"),
+  NEW("\$id"),
+  NONE("")
 }
 
 data class SchematicTypeData(val collection: String, val type: SchematicTypeEnum)

--- a/src/main/kotlin/com/github/etkachev/nxwebstorm/models/FullSchematicInfo.kt
+++ b/src/main/kotlin/com/github/etkachev/nxwebstorm/models/FullSchematicInfo.kt
@@ -23,6 +23,9 @@ fun mapSchematicTypeStringToEnum(type: String): SchematicTypeEnum {
   }
 }
 
+/**
+ * get id from schema.json. Will first find `id`, if not found, then look for `$id`, otherwise return null
+ */
 fun getIdFromJsonSchema(json: JsonObject): String? {
   val idProp = if (json.has(SchemaIdProp.STANDARD.prop)) {
     SchemaIdProp.STANDARD
@@ -36,8 +39,19 @@ fun getIdFromJsonSchema(json: JsonObject): String? {
 }
 
 enum class SchemaIdProp(val prop: String) {
+  /**
+   * the standard `id` prop of schema.json
+   */
   STANDARD("id"),
+
+  /**
+   * the new preferred property of `$id` for schema.json
+   */
   NEW("\$id"),
+
+  /**
+   * no property for id, used for null cases.
+   */
   NONE("")
 }
 


### PR DESCRIPTION
## Current Behavior

<!-- The behavior we have today before this PR is merged -->
- when searching nx custom schematics/generators, plugin searches schema.jsons via the `id` property.

## Expected Behavior

<!-- The behavior we will have after the PR is merged -->
- when searching nx custom schematics/generators, plugin should search schema.json files first by `id` property, then `$id` if former was not found.

## Motivation

<!-- Why is this behavior expected? -->
- better support on different schema json files.

## Related Issue

<!-- Please link an issue from github -->
<!-- that may provide more information regarding this PR -->
#71 

## Additional Notes

<!-- ... -->
